### PR TITLE
Apply pending changes to  v1.0 articles

### DIFF
--- a/articles/api-plugin-output.md
+++ b/articles/api-plugin-output.md
@@ -369,6 +369,11 @@ buffered output must implement this method.
 
 -   `chunk`: a buffer chunk (Fluent::Plugin::Buffer::Chunk)
 
+This method will be executed in parallel when `flush_thread_count` is
+larger than 1. So if your plugin modifies instance variables in this
+method, you need to protect it with `Mutex` or similar to avoid broken
+state.
+
 Return values will be ignored.
 
 
@@ -378,6 +383,11 @@ The method for async buffered output mode. The plugin which supports
 async buffered output must implement this method.
 
 -   `chunk`: a buffer chunk (Fluent::Plugin::Buffer::Chunk)
+
+This method will be executed in parallel when `flush_thread_count` is
+larger than 1. So if your plugin modifies instance variables in this
+method, you need to protect it with `Mutex` or similar to avoid broken
+state.
 
 Return values will be ignored.
 

--- a/articles/api-plugin-parser.md
+++ b/articles/api-plugin-parser.md
@@ -32,7 +32,7 @@ require 'fluent/plugin/parser'
 module Fluent::Plugin
   class TimeKeyValueParser < Parser
     # Register this parser as "time_key_value"
-    Plugin.register_parser("time_key_value", self)
+    Fluent::Plugin.register_parser("time_key_value", self)
 
     config_param :delimiter, :string, default: " "   # delimiter is configurable with " " as default
     config_param :time_format, :string, default: nil # time_format is configurable

--- a/articles/extract-section.md
+++ b/articles/extract-section.md
@@ -55,7 +55,7 @@ record.
         -   For more details about parsing, see
             [Time.strptime](https://docs.ruby-lang.org/en/2.4.0/Time.html#method-c-strptime)
         -   `%iso8601` (only for parsing)
-        -    Use `%N` to parse subsecond, because [strptime](https://github.com/nurse/strptime)
+        -    Use `%N` to parse/format subsecond, because [strptime](https://github.com/nurse/strptime)
             does not support `%3N`, `%6N`, `%9N`, and `%L`
 -   **localtime** (bool) (optional): if true, use local time. Otherwise,
     UTC is used. This is exclusive with `utc`.

--- a/articles/extract-section.md
+++ b/articles/extract-section.md
@@ -55,6 +55,8 @@ record.
         -   For more details about parsing, see
             [Time.strptime](https://docs.ruby-lang.org/en/2.4.0/Time.html#method-c-strptime)
         -   `%iso8601` (only for parsing)
+        -    Use `%N` to parse subsecond, because [strptime](https://github.com/nurse/strptime)
+            does not support `%3N`, `%6N`, `%9N`, and `%L`
 -   **localtime** (bool) (optional): if true, use local time. Otherwise,
     UTC is used. This is exclusive with `utc`.
     -   Default: `true`

--- a/articles/http-to-td.md
+++ b/articles/http-to-td.md
@@ -1,13 +1,13 @@
 # Cloud Big Data Analytics with Treasure Data
 
-This article explains how to use [Treasure Data](www.fluentd.org/treasuredata) with [Fluentd](http://fluentd.org/)
+This article explains how to use [Treasure Data](http://www.fluentd.org/treasuredata) with [Fluentd](http://fluentd.org/)
 to aggregate semi-structured logs into Treasure Data (TD), which offers
 Cloud Data Service.
 
 
 ## Background
 
-[Fluentd](http://fluentd.org/) is an advanced open-source log collector originally developed at [Treasure Data, Inc](www.fluentd.org/treasuredata). Fluentd is specifically designed to solve the big-data log collection problem.
+[Fluentd](http://fluentd.org/) is an advanced open-source log collector originally developed at [Treasure Data, Inc](http://www.fluentd.org/treasuredata). Fluentd is specifically designed to solve the big-data log collection problem.
 
 [Treasure Data](http://www.fluentd.org/treasuredata) provides Cloud Data Service, which Fluentd users can use to easily store and analyze data on the cloud. Fluentd is designed to flexibly connect with many systems via plugins, but Treasure Data should be your top choice if you don't want to spend engineering resources maintaining your backend infrastructure.
 

--- a/articles/inject-section.md
+++ b/articles/inject-section.md
@@ -80,7 +80,7 @@ Injected record is below:
         -   For more details about parsing, see
             [Time.strptime](https://docs.ruby-lang.org/en/2.4.0/Time.html#method-c-strptime)
         -   `%iso8601` (only for parsing)
-        -    Use `%N` to parse subsecond, because [strptime](https://github.com/nurse/strptime)
+        -    Use `%N` to parse/format subsecond, because [strptime](https://github.com/nurse/strptime)
             does not support `%3N`, `%6N`, `%9N`, and `%L`
 -   **localtime** (bool) (optional): if true, use local time. Otherwise,
     UTC is used. This is exclusive with `utc`.

--- a/articles/inject-section.md
+++ b/articles/inject-section.md
@@ -56,6 +56,8 @@ for plugins which support injecting values to the event record.
         -   For more details about parsing, see
             [Time.strptime](https://docs.ruby-lang.org/en/2.4.0/Time.html#method-c-strptime)
         -   `%iso8601` (only for parsing)
+        -    Use `%N` to parse subsecond, because [strptime](https://github.com/nurse/strptime)
+            does not support `%3N`, `%6N`, `%9N`, and `%L`
 -   **localtime** (bool) (optional): if true, use local time. Otherwise,
     UTC is used. This is exclusive with `utc`.
     -   Default: `true`

--- a/articles/inject-section.md
+++ b/articles/inject-section.md
@@ -16,6 +16,30 @@ for plugins which support injecting values to the event record.
 </match>
 ```
 
+### Example
+
+Here is an example of configuration and event:
+
+```
+# Configuration example
+<inject>
+  time_key fluentd_time
+  time_type string
+  time_format %Y-%m-%dT%H:%M:%S.%NZ
+  tag_key fluentd_tag
+</inject>
+
+# Record example
+tag: test
+time: 1547575563.952259
+record: {"message":"hello"}
+```
+
+Injected record is below:
+
+```
+{"message":"hello","fluetnd_tag":"test","fluentd_time":"2019-01-15T18:06:03.952259000Z"}
+```
 
 ## inject section parameter
 

--- a/articles/multi-process-workers.md
+++ b/articles/multi-process-workers.md
@@ -65,6 +65,83 @@ With this directive, you can mix multi-process ready and
 non-multi-process ready plugins in 1 instance.
 
 
+### &lt;worker N-M&gt; directive
+
+As of Fluentd v1.4.0, `<worker N-M>` syntax has been introduced:
+
+    :::text
+    <system>
+      workers 6
+    </system>
+
+    <worker 0-1>
+      <source>
+        @type forward
+      </source>
+
+      <filter test>
+        @type record_transformer
+        enable_ruby
+        <record>
+          worker_id ${ENV['SERVERENGINE_WORKER_ID']}
+        </record>
+      </filter>
+
+      <match test>
+        @type stdout
+      </match>
+    </worker>
+    # work on worker 0 and worker 1.
+
+    <worker 2-3>
+      <source>
+        @type tcp
+        <parse>
+          @type none
+        </parse>
+        tag test
+      </source>
+
+      <filter test>
+        @type record_transformer
+        enable_ruby
+        <record>
+          worker_id ${ENV['SERVERENGINE_WORKER_ID']}
+        </record>
+      </filter>
+
+      <match test>
+        @type stdout
+      </match>
+    </worker>
+    # work on worker 2 and worker 3.
+
+    <worker 4-5>
+      <source>
+        @type udp
+        <parse>
+          @type none
+        </parse>
+        tag test
+      </source>
+
+      <filter test>
+        @type record_transformer
+        enable_ruby
+        <record>
+          worker_id ${ENV['SERVERENGINE_WORKER_ID']}
+        </record>
+      </filter>
+
+      <match test>
+        @type stdout
+      </match>
+    </worker>
+    # work on worker 4 and worker 5.
+
+With this directive, you can specify multiple workers per worker directive.
+
+
 ### root\_dir/@id parameter
 
 These parameters must be specified when you use file buffer.

--- a/configuration/buffer-section.md
+++ b/configuration/buffer-section.md
@@ -488,10 +488,10 @@ performance (latency and throughput).
         of exponential backoff
 -   `retry_exponential_backoff_base` \[float\]
     -   Default: 2
-    -   The base number of exponencial backoff for retries
+    -   The base number of exponential backoff for retries
 -   `retry_max_interval` \[time\]
     -   Default: none
-    -   The maximum interval seconds for exponencial backoff between
+    -   The maximum interval seconds for exponential backoff between
         retries while failing
 -   `retry_randomize` \[bool\]
     -   Default: true

--- a/configuration/config-file.md
+++ b/configuration/config-file.md
@@ -39,6 +39,16 @@ $ sudo fluentd --setup /etc/fluent
 $ sudo vi /etc/fluent/fluent.conf
 ```
 
+### Docker
+
+If you're using the Docker container, the default location is located at
+/fluentd/etc/fluent.conf To mount a config file from outside of Docker,
+use a bind-mount.
+
+    ::: term
+    docker run -ti --rm -v /path/to/dir:/fluentd/etc fluentd -c /fluentd/etc/<conf-file> -v
+
+
 #### FLUENT\_CONF environment variable
 
 You can change default configuration file location via `FLUENT_CONF`.

--- a/configuration/config-file.md
+++ b/configuration/config-file.md
@@ -406,6 +406,9 @@ tags.
     -   This can be used in combination with the `*` or `**` patterns.
         Examples include `a.{b,c}.*` and `a.{b,c.**}`
 
+-   `#{...}` evaluates the string inside brackets as a Ruby expression
+    (See the section "Embedding Ruby Expressions" below)
+
 -   When multiple patterns are listed inside a single tag (delimited by
     one or more whitespaces), it matches any of the listed patterns. For
     example:
@@ -470,6 +473,17 @@ for the reason explained above.
 </match>
 ```
 
+### Embedding Ruby Expressions
+
+Since Fluentd v1.4.0, you can use `#{...}` to embed arbitrary Ruby code
+into match patterns. Here is an example.
+
+    <match "app.#{ENV['FLUENTD_TAG']}">
+      @type stdout
+    </match>
+
+If you set the environment variable `FLUENTD_TAG` to `dev`, this
+evaluates to `app.dev`.
 
 ## Supported Data Types for Values
 

--- a/configuration/format-section.md
+++ b/configuration/format-section.md
@@ -79,6 +79,8 @@ For more details, see plugins documentation.
         -   For more details about parsing, see
             [Time.strptime](https://docs.ruby-lang.org/en/2.4.0/Time.html#method-c-strptime)
         -   `%iso8601` (only for parsing)
+        -    Use `%N` to parse subsecond, because [strptime](https://github.com/nurse/strptime)
+            does not support `%3N`, `%6N`, `%9N`, and `%L`
 -   **localtime** (bool) (optional): if true, use local time. Otherwise,
     UTC is used. This is exclusive with `utc`.
     -   Default: `true`

--- a/configuration/format-section.md
+++ b/configuration/format-section.md
@@ -79,7 +79,7 @@ For more details, see plugins documentation.
         -   For more details about parsing, see
             [Time.strptime](https://docs.ruby-lang.org/en/2.4.0/Time.html#method-c-strptime)
         -   `%iso8601` (only for parsing)
-        -    Use `%N` to parse subsecond, because [strptime](https://github.com/nurse/strptime)
+        -    Use `%N` to parse/format subsecond, because [strptime](https://github.com/nurse/strptime)
             does not support `%3N`, `%6N`, `%9N`, and `%L`
 -   **localtime** (bool) (optional): if true, use local time. Otherwise,
     UTC is used. This is exclusive with `utc`.

--- a/configuration/parse-section.md
+++ b/configuration/parse-section.md
@@ -80,8 +80,8 @@ plugins.
 -   **time\_key** (string) (optional): Specify time field for event
     time. If the event doesn't have this field, current time is used.
     -   Default: `nil`
-    -   Note that [json](parser_json), [ltsv](parser_ltsv) and
-        [regexp](parser_regexp) override the default value of this
+    -   Note that [json](/plugins/parser/json), [ltsv](/plugins/parser/ltsv)
+        and [regexp](/plugins/parser/regexp) override the default value of this
         parameter and set it to `time` by default.
 -   **null\_value\_pattern** (string) (optional): Specify null value
     pattern.

--- a/configuration/parse-section.md
+++ b/configuration/parse-section.md
@@ -80,6 +80,9 @@ plugins.
 -   **time\_key** (string) (optional): Specify time field for event
     time. If the event doesn't have this field, current time is used.
     -   Default: `nil`
+    -   Note that [json](parser_json), [ltsv](parser_ltsv) and
+        [regexp](parser_regexp) override the default value of this
+        parameter and set it to `time` by default.
 -   **null\_value\_pattern** (string) (optional): Specify null value
     pattern.
     -   Default: `nil`

--- a/configuration/parse-section.md
+++ b/configuration/parse-section.md
@@ -165,7 +165,7 @@ the value is `"Adam|Alice|Bob"`, `types item_ids:array:|` parses it as
         -   For more details about parsing, see
             [Time.strptime](https://docs.ruby-lang.org/en/2.4.0/Time.html#method-c-strptime)
         -   `%iso8601` (only for parsing)
-        -    Use `%N` to parse subsecond, because [strptime](https://github.com/nurse/strptime)
+        -    Use `%N` to parse/format subsecond, because [strptime](https://github.com/nurse/strptime)
             does not support `%3N`, `%6N`, `%9N`, and `%L`
 -   **localtime** (bool) (optional): if true, use local time. Otherwise,
     UTC is used. This is exclusive with `utc`.

--- a/configuration/parse-section.md
+++ b/configuration/parse-section.md
@@ -162,6 +162,8 @@ the value is `"Adam|Alice|Bob"`, `types item_ids:array:|` parses it as
         -   For more details about parsing, see
             [Time.strptime](https://docs.ruby-lang.org/en/2.4.0/Time.html#method-c-strptime)
         -   `%iso8601` (only for parsing)
+        -    Use `%N` to parse subsecond, because [strptime](https://github.com/nurse/strptime)
+            does not support `%3N`, `%6N`, `%9N`, and `%L`
 -   **localtime** (bool) (optional): if true, use local time. Otherwise,
     UTC is used. This is exclusive with `utc`.
     -   Default: `true`

--- a/deployment/plugin-management.md
+++ b/deployment/plugin-management.md
@@ -193,7 +193,6 @@ even if td-agent includes them at the first time.
 
 The latest version is used. If command shows following result:
 
-    :::term
     $ fluent-gem list
     ...skip...
     fluent-plugin-record-modifier (2.0.1, 0.6.0, 0.5.0)

--- a/deployment/plugin-management.md
+++ b/deployment/plugin-management.md
@@ -187,6 +187,20 @@ NOTE: In this approach, you will download all gems listed in Gemfile
 even if td-agent includes them at the first time.
 
 
+## FAQ
+
+### fluent-gem list shows multiple plugin versions. Which version is used?
+
+The latest version is used. If command shows following result:
+
+    :::term
+    $ fluent-gem list
+    ...skip...
+    fluent-plugin-record-modifier (2.0.1, 0.6.0, 0.5.0)
+
+`2.0.1` version is used.
+
+
 ------------------------------------------------------------------------
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs/issues?state=open).

--- a/plugins/filter/geoip.md
+++ b/plugins/filter/geoip.md
@@ -50,8 +50,7 @@ The configuration shown below adds geolocation information to
   @type geoip
 
   # Specify one or more geoip lookup field which has ip address (default: host)
-  # in the case of accessing nested value, delimit keys by dot like 'host.ip'.
-  geoip_lookup_key  host
+  geoip_lookup_keys  host
 
   # Specify optional geoip database (using bundled GeoLiteCity databse by default)
   # geoip_database    "/path/to/your/GeoIPCity.dat"
@@ -110,6 +109,18 @@ Path to GeoIP database file.
 
 Path to GeoIP2 database file.
 
+### geoip\_lookup\_keys
+
+| type  | default  | version |
+|:-----:|:--------:|:-------:|
+| array | ["host"] | 1.2.0   |
+
+Specify one or more geoip lookup field which has IP address.
+
+See [record\_accessor](/articles/api-plugin-helper-record_accessor)
+about nested attributes.
+
+**NOTE** Since v1.3.0 does not interpret `host.ip` as nested attribute.
 
 ### geoip\_lookup\_key
 
@@ -119,8 +130,7 @@ Path to GeoIP2 database file.
 
 Specify one or more geoip lookup field which has ip address.
 
-In the case of accessing nested value, delimit keys by dot like
-'host.ip'.
++This parameter has been deprecated since v1.2.0.
 
 
 ### skip\_adding\_null\_record
@@ -159,7 +169,7 @@ fluent-plugin-elasticsearch
   backend_library geoip2_c
 
   # Set key name for the client ip address values
-  geoip_lookup_key     host
+  geoip_lookup_keys     host
 
   # Specify key name for the country_code values
   <record>

--- a/plugins/filter/grep.md
+++ b/plugins/filter/grep.md
@@ -158,6 +158,9 @@ We can also use \<or\> directive with \<regexp\> directive:
 
 Specify filtering rule. This directive contains two parameters.
 
+- key
+- pattern
+
 #### key
 
 | type   | default            | version |
@@ -265,6 +268,9 @@ regexp2 item_name ^book_
 
 Specify filtering rule to reject events. This directive contains two
 parameters.
+
+- key
+- pattern
 
 #### key
 

--- a/plugins/filter/parser.md
+++ b/plugins/filter/parser.md
@@ -205,10 +205,19 @@ Emit invalid record to `@ERROR` label. Invalid cases are
 
 You can rescue unexpected format logs in `@ERROR` label.
 
-In v1.0, `emit_invalid_record_to_error` is `true` by default unlike
-v0.12.
+If you want to ignore these errors, set `false`.
 
+## FAQ
 
+### suppress_parse_error_log is missing. What are the alternatives?
+
+Since v1, `parser` filter doesn't support `suppress_parse_error_log`
+parameter because `parser` filter uses `@ERROR` feature instead of
+internal logging to rescue invalid records. If you want to simply
+ignore invalid records, set `emit_invalid_record_to_error false`.
+
+See also `emit_invalid_record_to_error` parameter.
+ 
 ## Learn More
 
 -   [Filter Plugin Overview](/plugins/filter/README.md)

--- a/plugins/filter/parser.md
+++ b/plugins/filter/parser.md
@@ -1,7 +1,7 @@
 # parser Filter Plugin
 
-The `filter_parser` filter plugin "parses" string field in event records
-and mutates its event record with parsed result.
+The `parser` filter plugin "parses" string field in event records and
+mutates its event record with parsed result.
 
 
 ## Example Configurations
@@ -11,7 +11,7 @@ and mutates its event record with parsed result.
 ``` {.CodeRay}
 <filter foo.bar>
   @type parser
-  key_name message
+  key_name log
   <parse>
     @type regexp
     expression /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)$/
@@ -21,9 +21,23 @@ and mutates its event record with parsed result.
 ```
 
 `filter_parser` uses built-in parser plugins and your own customized
-parser plugin, so you can re-use pre-defined format like `apache`,
-`json` and etc. See document page for more details: [Parser Plugin Overview](/plugins/parser/README.md)
+parser plugin, so you can re-use pre-defined format like `apache2`,
+`json` and etc. See document page for more details:
+[Parser Plugin Overview](/plugins/parser/README.md)
 
+With this example, if you receive following event:
+
+    time:
+    injested time (depends on your input)
+    record:
+    {"log":"192.168.0.1 - - [05/Feb/2018:12:00:00 +0900] \"GET / HTTP/1.1\" 200 777"}
+
+parsed result is below:
+
+    time
+    05/Feb/2018:12:00:00 +0900
+    record:
+    {"host":"192.168.0.1","user":"-","method":"GET","path":"/","code":"200","size":"777"}
 
 ## Plugin helpers
 

--- a/plugins/filter/record_transformer.md
+++ b/plugins/filter/record_transformer.md
@@ -265,6 +265,26 @@ is light-weight and faster version of `filter_record_transformer`.
 you need better performace for mutating records, consider
 `filter_record_modifier` instead.
 
+## Tips
+
+### Use dig method for nested field
+
+Users sometimes need to access nested field. In this case, you can use `[]`
+chain like below.
+
+    ${record["top"]["nest1"]["nest2"]}
+
+But this approach has a problem. When `record["top"]` or
+`record["top"]["nest1"]` doesn't exist, you hit unexpected error.
+Here is log example:
+
+    error_class=RuntimeError error="failed to expand `record[\"top\"][\"nest1\"][\"nest2\"]` : error = undefined method `[]' for nil:NilClass
+
+`dig` method resolves this problem. If field not found, it return `nil`
+instead of raising error.
+
+    ${record.dig("top", "nest1", "nest2")}
+
 
 ## FAQ
 

--- a/plugins/filter/stdout.md
+++ b/plugins/filter/stdout.md
@@ -63,6 +63,9 @@ The format of output.
 This is the option of `stdout` format. Configure the format of record
 (third part). Any formatter plugins can be specified.
 
+### &lt;inject&gt; section
+
+See [Inject section configurations](/articles/inject-section) for more details.
 
 ## Learn More
 

--- a/plugins/formatter/json.md
+++ b/plugins/formatter/json.md
@@ -35,11 +35,6 @@ This incoming event is formatted to:
 {"host":"192.168.0.1","size":777,"method":"PUT"}
 ```
 
-With `include_tag_key true` and `tag_key event_tag`, result is:
-
-``` {.CodeRay}
-{"host":"192.168.0.1","size":777,"method":"PUT","event_tag":"app.event"}
-```
 
 
 ------------------------------------------------------------------------

--- a/plugins/formatter/msgpack.md
+++ b/plugins/formatter/msgpack.md
@@ -23,11 +23,6 @@ This incoming event is formatted to:
 {"host":"192.168.0.1","size":777,"method":"PUT"}
 ```
 
-With `include_tag_key true` and `tag_key event_tag`, result is:
-
-``` {.CodeRay}
-\x83\xA4host\xAB192.168.0.1\xA4size\xCD\x03\t\xA6method\xA3PUT
-```
 
 
 ------------------------------------------------------------------------

--- a/plugins/input/forward.md
+++ b/plugins/input/forward.md
@@ -395,6 +395,8 @@ $ openssl s_client -connect localhost:24224 \
 If the connection gets established successfully, your setup is working
 fine.
 
++For fluentd and fluent-bit combination, see Banzai Cloud article:
+[Secure logging on Kubernetes with Fluentd and Fluent Bit](https://banzaicloud.com/blog/k8s-logging-tls/)
 
 ### How to Enable Password Authentication
 

--- a/plugins/input/forward.md
+++ b/plugins/input/forward.md
@@ -169,6 +169,11 @@ Without `<transport tls>`, in\_forward uses raw TCP.
 
 This section contains parameters related to authentication.
 
+- self\_hostname
+- shared\_key
+- user\_auth
+- allow\_anonymous\_source
+
 #### self\_hostname
 
 | type   | default            | version |
@@ -209,6 +214,11 @@ Allow anonymous source. `<client>` sections are required if disabled.
 
 This section contains user based authentication.
 
+- username
+- password
+
+This section can be used in `<security>`.
+
 ##### username
 
 | type   | default            | version |
@@ -233,6 +243,13 @@ The password for authentication.
 
 This section contains that client IP/Network authentication and shared
 key per host.
+
+- host
+- network
+- shared\_key
+- users
+
+This section can be used in `<security>`
 
 ##### host
 

--- a/plugins/input/forward.md
+++ b/plugins/input/forward.md
@@ -4,12 +4,14 @@
 
 The `in_forward` Input plugin listens to a TCP socket to receive the
 event stream. It also listens to an UDP socket to receive heartbeat
-messages.
+messages. See also "protocol" section for implementation details.
 
 This plugin is mainly used to receive event logs from other Fluentd
-instances, the fluent-cat command, or client libraries. This is by far
-the most efficient way to retrieve the records.
+instances, the fluent-cat command, or Fluentd client libraries.
+This is by far the most efficient way to retrieve the records.
 
+If you want to receive events from raw tcp payload, use `in_tcp`
+plugin instead.
 
 ## Example Configuration
 

--- a/plugins/input/syslog.md
+++ b/plugins/input/syslog.md
@@ -116,6 +116,29 @@ The max bytes of syslog message. If you send larger message, change this
 parameter.
 
 
+### frame\_type
+
+| type | default | available values |version |
+|:----:|:-------:|:----------------::-------:|
+| enum | traditional | traditional/octet\_count | 1.3.0 |
+
+Specify framing type in TCP protocol. 
+
+- traditional
+
+Messages are delimited by newline(`\n`)
+
+    <6>Sep 10 00:00:00 localhost logger: hello!\n
+
+- octet\_count
+
+Message has message size prefix to delimite
+
+    44 <6>Sep 10 00:00:00 localhost logger: hello!
+
+See also [rfc6587](https://tools.ietf.org/html/rfc6587#section-3.4).
+
+
 ### format
 
 Deprecated parameter. Use `<parse>` instead.

--- a/plugins/input/tail.md
+++ b/plugins/input/tail.md
@@ -447,6 +447,16 @@ several reports in\_tail is stopped when use `*` included `path`, and
 the problem is resolved by disabling inotify events.
 
 
+### Wildcard pattern in path doesn't work on Windows, why?
+
+Backslash(`\`) with `*` doesn't work on Windows by internal limitation.
+To avoid this problm, use slash style instead.
+
+    # good
+    path C:/path/to/*/foo.log
+    # bad
+    path C:\\path\\to\\*\\foo.log
+
 ------------------------------------------------------------------------
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs/issues?state=open).

--- a/plugins/input/tcp.md
+++ b/plugins/input/tcp.md
@@ -117,6 +117,30 @@ then the client's hostname is set to `client_host` field.
 }
 ```
 
+### source\_address\_key
+
+| type   | default                        | version |
+|:------:|:------------------------------:|:-------:|
+| string | nil (no adding source address) | 1.4.2   |
+
+The field name for the client's IP address. If you set this option, Fluentd automatically adds the remote address to each data record.
+
+For example, if you have the following configuration:
+
+    <source>
+      @type tcp
+      source_address_key client_addr
+      ...
+    </source>
+
+you will get something like below:
+
+    :::text
+    {
+        ...
+        "client_addr": "192.168.10.10"
+        ...
+    }
 
 ### &lt;parse&gt; section
 

--- a/plugins/input/tcp.md
+++ b/plugins/input/tcp.md
@@ -133,6 +133,21 @@ For more details about parser plugin, see followings:
 -   [Parse section configurations](/configuration/parse-section.md)
 
 
+## Code example
+
+Here is ruby example to send event to `in_tcp`.
+
+```
+require 'socket'
+
+# This example uses json payload.
+# In in_tcp configuration, need to configure "@type json" in "<parse>"
+TCPSocket.open('127.0.0.1', 5170) do |s|
+  s.write('{"k":"v1"}' + "\n")
+  s.write('{"k":"v2"}' + "\n")
+end
+```
+
 ------------------------------------------------------------------------
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs/issues?state=open).

--- a/plugins/input/tcp.md
+++ b/plugins/input/tcp.md
@@ -4,9 +4,8 @@
 
 The `in_tcp` Input plugin enables Fluentd to accept TCP payload.
 
-Don't use this plugin for receiving logs from client libraries. Use
-`in_forward` for such cases.
-
+Don't use this plugin for receiving logs from Fluentd client
+libraries. Use `in_forward` for such cases.
 
 ## Example Configuration
 

--- a/plugins/input/udp.md
+++ b/plugins/input/udp.md
@@ -103,6 +103,32 @@ then the client's hostname is set to `client_host` field.
 }
 ```
 
+### source\_address\_key
+
+| type   | default                        | version |
+|:------:|:------------------------------:|:-------:|
+| string | nil (no adding source address) | 1.4.2   |
+
+The field name for the client's IP address. If you set this option,
+Fluentd automatically adds the remote address to each data record.
+
+For example, if you have the following configuration:
+
+    <source>
+      @type udp
+      source_address_key client_addr
+      ...
+    </source>
+
+you will get something like below:
+
+    :::text
+    {
+        ...
+        "client_addr": "192.168.10.10"
+        ...
+    }
+
 
 ### message\_length\_limit
 

--- a/plugins/input/udp.md
+++ b/plugins/input/udp.md
@@ -136,6 +136,24 @@ For more details about parser plugin, see followings:
 -   [Parse section configurations](/configuration/parse-section.md)
 
 
+## Code example
+
+Here is ruby example to send event to `in_udp`.
+
+```
+require 'socket'
+
+us = UDPSocket.open
+sa = Socket.pack_sockaddr_in(5160, '127.0.0.1')
+
+# This example uses json payload.
+# In in_udp configuration, need to configure "@type json" in "<parse>"
+us.send('{"k":"v1"}', 0, sa)
+us.send('{"k":"v2"}', 0, sa)
+us.close
+```
+
+
 ## FAQ
 
 

--- a/plugins/output/README.md
+++ b/plugins/output/README.md
@@ -240,7 +240,7 @@ exponential backoff.
 
 The default is 2
 
-The base number of exponencial backoff for retries.
+The base number of exponential backoff for retries.
 
 #### retry\_max\_interval
 

--- a/plugins/output/README.md
+++ b/plugins/output/README.md
@@ -184,12 +184,12 @@ destinations. For monitoring, newer events are important than older.
 
 If the bottom chunk write out fails, it will remain in the queue and
 Fluentd will retry after waiting several seconds (`retry_wait`). If the
-retry limit has not been disabled (`retry_forever` is true) and the
-retry count exceeds the specified limit (`retry_max_times`), the chunk
-is trashed. The retry wait time doubles each time (1.0sec, 2.0sec,
-4.0sec, ...) until `retry_max_interval` is reached. If the queue length
-exceeds the specified limit (`queue_limit_length`), new events are
-rejected.
+retry limit has not been disabled (`retry_forever` is false) and the
+retry count exceeds the specified limit (`retry_max_times`), **all chunks
+in the queue are discarded**. The retry wait time doubles each time
+(1.0sec, 2.0sec, 4.0sec, ...) until `retry_max_interval` is reached.
+If the queue length exceeds the specified limit (`queue_limit_length`),
+new events are rejected.
 
 writing out the bottom chunk is considered to be a failure if
 \"Output\#write\" or \`Output\#try\_write\` method throws an exception.

--- a/plugins/output/README.md
+++ b/plugins/output/README.md
@@ -80,7 +80,7 @@ Example of v1.0 output plugin configuration:
     timekey     60m
     timekey_wait 1m
   </buffer>
-</source>
+</match>
 ```
 
 For Fluentd v0.12, configuration parameters for buffer plugins were
@@ -94,7 +94,7 @@ written in same section:
   buffer_path /my/buffer/myservice/access.myservice_name.*.log
   time_slice_format %Y-%m-%d.%H%M
   time_slice_wait   1m
-</source>
+</match>
 ```
 
 See buffer section in [Compat Parameters Plugin Helper

--- a/plugins/output/README.md
+++ b/plugins/output/README.md
@@ -150,6 +150,16 @@ The default is 60.
 
 Seconds of timeout for buffer chunks to be committed by plugins later
 
+#### slow\_flush\_log\_threshold
+
+The threshold for chunk flush performance check. The default value is
+`20.0` seconds. Note that parameter type is `float`, not `time`.
+
+If chunk flush takes longer time than this threshold, fluentd logs
+warning message like below:
+
+    2016-12-19 12:00:00 +0000 [warn]: buffer flush took longer time than slow_flush_log_threshold: elapsed_time=15.0031226690043695 slow_flush_log_threshold=10.0 plugin_id="foo"
+
 #### overflow\_action
 
 Control the buffer behaviour when the queue becomes full. 3 modes are

--- a/plugins/output/elasticsearch.md
+++ b/plugins/output/elasticsearch.md
@@ -150,6 +150,10 @@ logging for each plugin. The supported log levels are: `fatal`, `error`,
 
 Please see the [logging article](/deployment/logging.md) for further details.
 
+### logstash\_prefix (optional)
+
+The logstash prefix index name to write events when specifying
+logstash\_format as true (default: `logstash`).
 
 ## Miscellaneous
 

--- a/plugins/output/file.md
+++ b/plugins/output/file.md
@@ -131,7 +131,7 @@ Deprecated parameter. Use `<format>` instead.
 
 ### &lt;inject&gt; section
 
-See [Inject section configurations](inject-section) for more details.
+See [Inject section configurations](/articles/inject-section) for more details.
 
 
 ### utc

--- a/plugins/output/file.md
+++ b/plugins/output/file.md
@@ -223,6 +223,42 @@ After flushed, you see actual output result
 
 See also note in `path` parameter.
 
+### Can I use a placeholder in symlink\_path?
+
+Since Fluentd v1.4.0, you can use the placeholder syntax in
+`symlink_path` parameter. For example, suppose you have the
+following configuration.
+
+    <source>
+      @type dummy
+      tag dummy1
+    </source>
+
+    <source>
+      @type dummy
+      tag dummy2
+    </source>
+
+    <match dummy*>
+      @type file
+      path /tmp/logs/${tag}
+      symlink_path /tmp/logs/current-${tag}
+      <buffer tag,time>
+        @type file
+      </buffer>
+    </match>
+
+This produces the following directory layout.
+
+    $ tree /tmp/logs/
+    /tmp/logs/
+    ├── ${tag}
+    │   ├── buffer.b57fb1dd96306dd0b308e094f7ec2228f.log
+    │   ├── buffer.b57fb1dd96306dd0b308e094f7ec2228f.log.meta
+    │   ├── buffer.b57fb1dd96339a870530991d4871cfe11.log
+    │   └── buffer.b57fb1dd96339a870530991d4871cfe11.log.meta
+    ├── current-dummy1 -> /tmp/logs/${tag}/buffer.b57fb1dd96339a870530991d4871cfe11.log
+    └── current-dummy2 -> /tmp/logs/${tag}/buffer.b57fb1dd96306dd0b308e094f7ec2228f.log
 
 ------------------------------------------------------------------------
 

--- a/plugins/output/file.md
+++ b/plugins/output/file.md
@@ -129,6 +129,11 @@ See [formatter article](/plugins/formatter/README.md) for more detail.
 Deprecated parameter. Use `<format>` instead.
 
 
+### &lt;inject&gt; section
+
+See [Inject section configurations](inject-section) for more details.
+
+
 ### utc
 
 Deprecated parameter. Use `timekey_use_utc` in `<buffer>` instead.

--- a/plugins/output/forward.md
+++ b/plugins/output/forward.md
@@ -85,8 +85,17 @@ The value must be `forward`.
 |:---------|:------|:--------|
 | true     | true  | 0.14.5  |
 
-The destination servers. Each server must have following information.
+The destination servers. Each server has following parameters.
 
+- host
+- name
+- port
+- shared\_key
+- username
+- password
+- standby
+- weight
+ 
 #### host
 
 | type   | default            | version |
@@ -388,6 +397,9 @@ The client private key passphrase for TLS.
 
 This section contains parameters related to authentication.
 
+- self\_hostname
+- shared\_key
+
 #### self\_hostname
 
 | type   | default            | version |
@@ -402,8 +414,8 @@ The hostname.
 |:-------|:-------------------|:--------|
 | string | required parameter | 0.14.5  |
 
-Shared key for authentication.
-
+Shared key for authentication. If you want to specify `shared_key`
+for specific server, use `<server>` section.
 
 ### &lt;secondary&gt;
 

--- a/plugins/output/forward.md
+++ b/plugins/output/forward.md
@@ -352,10 +352,33 @@ Verify hostname of servers and certificates or not in TLS transport.
 
 | type            | default | version |
 |:----------------|:--------|:--------|
-| array of string | false   | 0.14.12 |
+| array of string | nil     | 0.14.12 |
 
 The additional CA certificate path for TLS.
 
+### tls\_client\_cert\_pat
+
+| type   | default | version |
+|:------:|:-------:|:-------:|
+| string | nil     | 1.3.2   |
+
+The client certificate path for TLS
+
+### tls\_client\_private\_key\_path
+
+| type   | default | version |
+|:------:|:-------:|:-------:|
+| string | nil     | 1.3.2   |
+
+The client private key path for TLS.
+
+### tls\_client\_private\_key\_passphrase
+
+| type   | default | version |
+|:------:|:-------:|:-------:|
+| string | nil     | 1.3.2   |
+
+The client private key passphrase for TLS.
 
 ### &lt;security&gt; section
 

--- a/plugins/output/stdout.md
+++ b/plugins/output/stdout.md
@@ -101,6 +101,9 @@ The format of output.
 This is the option of `stdout` format. Configure the format of record
 (third part). Any formatter plugins can be specified.
 
+### &lt;inject&gt; section
+
+See [Inject section configurations](/articles/inject-section) for more details.
 
 ------------------------------------------------------------------------
 

--- a/plugins/parser/regexp.md
+++ b/plugins/parser/regexp.md
@@ -25,8 +25,26 @@ See [Parse section configurations](/configuration/parse-section.md) for common p
 |:-------|:-------------------|:--------|
 | regexp | required parameter | 1.2.0   |
 
-Regular expression for matching logs.
+Regular expression for matching logs. Regular expression also supports
+`i` and `m` suffix.
 
+#### i (ignorecase)
+
+Ignore case in matching.
+
+    expression /.../i
+
+#### m (multiline)
+
+Build regular expression as a multiline mode. `.` matches newline. See
+[Ruby's Regexp document](https://ruby-doc.org/core-2.4.1/Regexp.html#class-Regexp-label-Options)
+
+    expression /.../m
+
+#### both
+
+    expression /.../im
+ 
 expression is string type before 1.2.0.
 
 


### PR DESCRIPTION
This is a collection of patches for v1.0 articles since https://github.com/fluent/fluentd-docs/commit/6dad0eab466889ccae9972145f7e9054680a1c15

Since the directory layout has been changed, I have applied
each patch manually one by one, fixing their contents to fit the
GitBook style formatting.

With this, the v1.0 documentation should sync with v1.4.2.