### PR TITLE
plugins: input: Add documentation for in_unix

### DIFF
--- a/plugins/input/README.md
+++ b/plugins/input/README.md
@@ -22,6 +22,7 @@ data sources.
 -   [in\_forward](/plugins/input/forward.md)
 -   [in\_udp](/plugins/input/udp.md)
 -   [in\_tcp](/plugins/input/tcp.md)
+-   [in\_unix](/plugins/input/unix.md)
 -   [in\_http](/plugins/input/http.md)
 -   [in\_syslog](/plugins/input/syslog.md)
 -   [in\_exec](/plugins/input/exec.md)

--- a/plugins/input/unix.md
+++ b/plugins/input/unix.md
@@ -1,0 +1,48 @@
+# Unix Domain Socket Input Plugin
+
+The `in_unix` Input plugin enables Fluentd to retrieve records from
+the Unix Domain Socket. The wire protocol is the same as
+[in_forward](/plugins/input/forward), but the transport layer is
+different.
+
+## Example Configuration
+
+`in_unix` is included in Fluentd's core. No additional installation
+process is required.
+
+    <source>
+      @type unix
+      path /path/to/socket.sock
+    </source>
+
+NOTE: Please see the [Config File](/configuration/config-file) article
+for the basic structure and syntax of the configuration file.
+
+## Parameters
+
+### @type (required)
+
+The value must be `unix`.
+
+### path
+
+| type   | default                                   | version |
+|:------:|:-----------------------------------------:|:-------:|
+| string | `/var/run/fluent/fluent.sock` (see below) | 0.14.0  |
+
+The path to your Unix Domain Socket.
+
+Fluentd will use the environment variable `FLUENT_SOCKET` if defined.
+
+### backlog
+
+| type    | default | version |
+|:-------:|:-------:|:-------:|
+| integer | 1024    | 0.14.0  |
+
+The backlog of Unix Domain Socket.
+
+------------------------------------------------------------------------
+
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs/issues?state=open).
+[Fluentd](http://www.fluentd.org/) is a open source project under [Cloud Native Computing Foundation (CNCF)](https://cncf.io/). All components are available under the Apache 2 License.


### PR DESCRIPTION
Right now GitBook site lacks the manual for in_unix. So I bring the
manual document from the old site, and migrates the content to
GitBook format.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>