### PR TITLE
overview: import a fix from the old documentation

### DIFF
--- a/overview/post-installation-guide.md
+++ b/overview/post-installation-guide.md
@@ -128,10 +128,12 @@ need to write as below:
 
 ``` {.CodeRay}
 <match debug.log>
-  @type syslog
+  @type kafka2
   port 5140
+  brokers kafka-server:9092
   tag system
-</source>
+  # other parameters...
+</match>
 ```
 
 You can use a wildcard character `*` in the filter expression. For


### PR DESCRIPTION
This imports a fix from fluent/fluentd-docs. For details,
please follow the link below:

https://github.com/fluent/fluentd-docs/commit/2e23a10

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>