### PR TITLE
Fix broken links in the Gitbook documentations

### DIFF
--- a/overview/update-from-v0.12.md
+++ b/overview/update-from-v0.12.md
@@ -1,7 +1,7 @@
 # Updating Fluentd for v1 from v0.12
 
 This guide is for users to show how to update Fluentd to v1.0 from v0.12
-or earlier. For plugin developer, see [Updating plugin for v1.0 from v0.12](plugin-update-from-v0.12).
+or earlier. For plugin developer, see [Updating plugin for v1.0 from v0.12](/articles/plugin-update-from-v0.12).
 
 There are something to be considered:
 

--- a/plugins/input/unix.md
+++ b/plugins/input/unix.md
@@ -2,7 +2,7 @@
 
 The `in_unix` Input plugin enables Fluentd to retrieve records from
 the Unix Domain Socket. The wire protocol is the same as
-[in_forward](/plugins/input/forward), but the transport layer is
+[in_forward](/plugins/input/forward.md), but the transport layer is
 different.
 
 ## Example Configuration
@@ -10,12 +10,14 @@ different.
 `in_unix` is included in Fluentd's core. No additional installation
 process is required.
 
-    <source>
-      @type unix
-      path /path/to/socket.sock
-    </source>
+```
+<source>
+  @type unix
+  path /path/to/socket.sock
+</source>
+```
 
-NOTE: Please see the [Config File](/configuration/config-file) article
+NOTE: Please see the [Config File](/configuration/config-file.md) article
 for the basic structure and syntax of the configuration file.
 
 ## Parameters

--- a/plugins/output/README.md
+++ b/plugins/output/README.md
@@ -21,7 +21,7 @@ Fluentd v1.0 output plugins have 3 modes about buffering and flushing.
     output plugin will not commit writing chunks in methods
     synchronously, but commit later.
 
-![Fluentd v1.0 Plugin API Overview](//docs.fluentd.org/images/fluentd-v0.14-plugin-api-overview.png)
+![Fluentd v1.0 Plugin API Overview](/images/fluentd-v0.14-plugin-api-overview.png)
 
 Output plugins can support all modes, but may support just one of these
 modes. Fluentd choose appropriate mode automatically if there are no


### PR DESCRIPTION
This is a collections of fixes for broken links I found while
reading the new GitBook site.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>