### PR TITLE
Escape <> brackets properly

### DIFF
--- a/plugins/filter/grep.md
+++ b/plugins/filter/grep.md
@@ -62,8 +62,8 @@ whereas the following examples are filtered out:
 
 ### &lt;and&gt; directive
 
-Specify filtering rule. This directive contains either \<regexp\> or
-\<exclude\> directive. This directive has been added since 1.2.0.
+Specify filtering rule. This directive contains either `<regexp>` or
+`<exclude>` directive. This directive has been added since 1.2.0.
 
 ``` {.CodeRay}
 <and>
@@ -91,7 +91,7 @@ This is same as below:
 </regexp>
 ```
 
-We can also use \<and\> directive with \<exclude\> directive:
+We can also use `<and>` directive with `<exclude>` directive:
 
 ``` {.CodeRay}
 <and>
@@ -109,8 +109,8 @@ We can also use \<and\> directive with \<exclude\> directive:
 
 ### &lt;or&gt; directive
 
-Specify filtering rule. This directive contains either \<regexp\> or
-\<exclude\> directive. This directive has been added since 1.2.0.
+Specify filtering rule. This directive contains either `<regexp>` or
+`<exclude>` directive. This directive has been added since 1.2.0.
 
 ``` {.CodeRay}
 <or>
@@ -138,7 +138,7 @@ This is same as below:
 </exclude>
 ```
 
-We can also use \<or\> directive with \<regexp\> directive:
+We can also use `<or>` directive with `<regexp>` directive:
 
 ``` {.CodeRay}
 <or>

--- a/plugins/input/forward.md
+++ b/plugins/input/forward.md
@@ -208,7 +208,7 @@ If true, use user based authentication.
 
 Allow anonymous source. `<client>` sections are required if disabled.
 
-#### \<user\> section
+#### `<user>` section
 
 | required | multi | version |
 |:---------|:------|:--------|
@@ -237,7 +237,7 @@ The username for authentication.
 
 The password for authentication.
 
-#### \<client\> section
+#### `<client>` section
 
 | required | multi | version |
 |:---------|:------|:--------|

--- a/plugins/input/syslog.md
+++ b/plugins/input/syslog.md
@@ -230,7 +230,7 @@ This parameter is used inside `<parse>` directive.
 ```
 
 If `with_priority` is true, then syslog messages are assumed to be
-prefixed with a priority tag like "\<3\>". This option exists since some
+prefixed with a priority tag like `<3>`. This option exists since some
 syslog daemons output logs without the priority tag preceding the
 message body.
 

--- a/plugins/input/tail.md
+++ b/plugins/input/tail.md
@@ -24,7 +24,7 @@ process is required.
 ```
 
 Please see the [Config File](/configuration/config-file.md) article for the basic
-structure and syntax of the configuration file. For \<parse\> section,
+structure and syntax of the configuration file. For `<parse>` section,
 please check [Parse section cofiguration](/configuration/parse-section.md).
 
 

--- a/plugins/input/tcp.md
+++ b/plugins/input/tcp.md
@@ -39,7 +39,7 @@ Parsed result like below:
 ```
 
 Please see the [Config File](/configuration/config-file.md) article for the basic
-structure and syntax of the configuration file. For \<parse\> section,
+structure and syntax of the configuration file. For `<parse>` section,
 please check [Parse section cofiguration](/configuration/parse-section.md).
 
 We\'ve observed the drastic performance improvements on Linux, with

--- a/plugins/input/udp.md
+++ b/plugins/input/udp.md
@@ -25,11 +25,11 @@ process is required.
 ```
 
 Please see the [Config File](/configuration/config-file.md) article for the basic
-structure and syntax of the configuration file. For \<parse\> section,
+structure and syntax of the configuration file. For `<parse>` section,
 please check [Parse section cofiguration](/configuration/parse-section.md).
 
-We\'ve observed the drastic performance improvements on Linux, with
-proper kernel parameter settings (e.g. \`net.core.rmem\_max\`
+We've observed the drastic performance improvements on Linux, with
+proper kernel parameter settings (e.g. `net.core.rmem_max`
 parameter). If you have high-volume UDP traffic, please make sure to
 follow the instruction described at [Before Installing Fluentd](/install/before-install.md).
 

--- a/plugins/output/copy.md
+++ b/plugins/output/copy.md
@@ -101,7 +101,7 @@ When `deep_copy` is true, `out_copy` passes dupped record to each
 ### &lt;store&gt; section
 
 Specifies the storage destinations. The format is the same as the
-\<match\> directive.
+`<match>` directive.
 
 This section is required at least once.
 

--- a/plugins/output/exec_filter.md
+++ b/plugins/output/exec_filter.md
@@ -36,7 +36,7 @@ installation process is required.
 Please see the [Config File](/configuration/config-file.md) article for the basic
 structure and syntax of the configuration file.
 
-When using the json format in \<parse\> section, this plugin uses the
+When using the json format in `<parse>` section, this plugin uses the
 Yajl library to parse the program output. Yajl buffers data internally
 so the output isn't always instantaneous.
 

--- a/plugins/output/file.md
+++ b/plugins/output/file.md
@@ -29,7 +29,7 @@ process is required.
 ```
 
 Please see the [Config File](/configuration/config-file.md) article for the basic
-structure and syntax of the configuration file. For \<buffer\> section,
+structure and syntax of the configuration file. For `<buffer>` section,
 please check [Buffer section cofiguration](/configuration/buffer-section.md).
 
 

--- a/plugins/output/mongo.md
+++ b/plugins/output/mongo.md
@@ -72,7 +72,7 @@ Please see the [Store Apache Logs into MongoDB](/guides/apache-to-mongodb.md)
 article for real-world use cases.
 
 Please see the [Config File](/configuration/config-file.md) article for the basic
-structure and syntax of the configuration file. For \<buffer\> section,
+structure and syntax of the configuration file. For `<buffer>` section,
 please check [Buffer section cofiguration](/configuration/buffer-section.md).
 
 

--- a/plugins/output/mongo_replset.md
+++ b/plugins/output/mongo_replset.md
@@ -60,7 +60,7 @@ Please see the [Store Apache Logs into MongoDB](/guides/apache-to-mongodb.md)
 article for real-world use cases.
 
 Please see the [Config File](/configuration/config-file.md) article for the basic
-structure and syntax of the configuration file. For \<buffer\> section,
+structure and syntax of the configuration file. For `<buffer>` section,
 please check [Buffer section cofiguration](/configuration/buffer-section.md).
 
 

--- a/plugins/output/rewrite_tag_filter.md
+++ b/plugins/output/rewrite_tag_filter.md
@@ -130,7 +130,7 @@ for further details.
 
 ### rewriteruleN
 
-This is obsoleted since 2.0.0. Use \<rule\> section.
+This is obsoleted since 2.0.0. Use `<rule>` section.
 
 
 ### capitalize\_regex\_backreference

--- a/plugins/output/roundrobin.md
+++ b/plugins/output/roundrobin.md
@@ -55,7 +55,7 @@ The value must be `roundrobin`.
 ### &lt;store&gt;
 
 Specifies the storage destinations. The format is the same as the
-\<match\> directive.
+`<match>` directive.
 
 #### weight
 

--- a/plugins/output/s3.md
+++ b/plugins/output/s3.md
@@ -52,7 +52,7 @@ for real-world use cases.
 Please see the [Config File](/configuration/config-file.md) article for the basic
 structure and syntax of the configuration file.
 
-For \<buffer\> section, please check [Buffer section cofiguration](/configuration/buffer-section.md). This plugin uses [file buffer](/plugins/buffer/file.md)
+For `<buffer>` section, please check [Buffer section cofiguration](/configuration/buffer-section.md). This plugin uses [file buffer](/plugins/buffer/file.md)
 by default.
 
 

--- a/plugins/output/webhdfs.md
+++ b/plugins/output/webhdfs.md
@@ -66,7 +66,7 @@ cluster.
 Please see the [Fluentd + HDFS: Instant Big Data Collection](http-to-hdfs) article for real-world use cases.
 
 Please see the [Config File](/configuration/config-file.md) article for the basic
-structure and syntax of the configuration file. For \<buffer\> section,
+structure and syntax of the configuration file. For `<buffer>` section,
 please check [Buffer section cofiguration](/configuration/buffer-section.md).
 
 

--- a/plugins/parser/regexp.md
+++ b/plugins/parser/regexp.md
@@ -1,7 +1,7 @@
 # regexp Parser Plugin
 
 The `regexp` parser plugin parses logs by given regexp pattern. The
-regexp must have at least one named capture (?\<NAME\>PATTERN). If the
+regexp must have at least one named capture (`?<NAME>`PATTERN). If the
 regexp has a capture named `time`, this is configurable via `time_key`
 parameter, it is used as the time of the event. You can specify the time
 format using the time\_format parameter.

--- a/plugins/parser/syslog.md
+++ b/plugins/parser/syslog.md
@@ -13,7 +13,7 @@ See [Parse section configurations](/configuration/parse-section.md)
 
 | type   | default         | version |
 |:-------|:----------------|:--------|
-| string | \%b %d %H:%M:%S | 0.14.10 |
+| string | %b %d %H:%M:%S  | 0.14.10 |
 
 Specify time format for event time. Default is "%b %d %H:%M:%S" for
 rfc3164 protocol.
@@ -23,7 +23,7 @@ rfc3164 protocol.
 
 | type   | default                 | version |
 |:-------|:------------------------|:--------|
-| string | \%Y-%m-%dT%H:%M:%S.%L%z | 0.14.14 |
+| string | %Y-%m-%dT%H:%M:%S.%L%z  | 0.14.14 |
 
 Specify time format for event time for rfc5424 protocol.
 
@@ -51,7 +51,7 @@ via syslog don't have `<9>` like priority prefix.
 |:-----|:--------|:--------|
 | bool | false   | 0.14.0  |
 
-If the incoming logs have priority prefix, e.g. \<9\>, set `true`.
+If the incoming logs have priority prefix, e.g. `<9>`, set `true`.
 Default is `false`.
 
 


### PR DESCRIPTION
Gitbook won't recognize `\<` or `\>` as escaped brackets, and
will embed them as is. This breaks the rendered HTML.

This patch fixes these wrong escapes to use backticks instead.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>