### PR TITLE
Fix a few more broken links

### DIFF
--- a/deployment/performance-tuning-single-process.md
+++ b/deployment/performance-tuning-single-process.md
@@ -5,8 +5,8 @@ single process. If your traffic is up to 5,000 messages/sec, the
 following techniques should be enough.
 
 With more traffic, Fluentd tends to be more CPU bound. In such case,
-please consider using ["multi-worker"
-feature](performance-tuning-single-process#multi-workers).
+please consider using
+["multi-worker" feature](/deployment/multi-process-workers.md).
 
 
 ## Check your OS configuration

--- a/developer/api-plugin-formatter.md
+++ b/developer/api-plugin-formatter.md
@@ -1,9 +1,9 @@
 # Writing Formatter Plugins
 
-Fluentd supports [pluggable, customizable formats for output
-plugins](formatter-plugin-overview). The plugin files whose names start
-with "formatter\_" are registered as Formatter Plugins. See [Plugin Base Class API](/developer/api-plugin-base.md) to show details of common API for all plugin
-types.
+Fluentd supports [pluggable, customizable formats for output plugins](/plugins/formatter/README.md).
+The plugin files whose names start with "formatter\_" are registered as
+Formatter Plugins. See [Plugin Base Class API](/developer/api-plugin-base.md)
+to show details of common API for all plugin types.
 
 Here is an example of a custom formatter that outputs events as CSVs. It
 takes a required parameter called "csv\_fields" and outputs the fields.

--- a/guides/splunk-like-grep-and-alert-email.md
+++ b/guides/splunk-like-grep-and-alert-email.md
@@ -10,7 +10,8 @@ sends an alert email when it detects a 5xx HTTP status code in an Apache
 access log.
 
 If you want a more general introduction to use Fluentd as a free
-alternative to Splunk, see the article ["Free Alternative to Splunk Using Fluentd"](free-alternative-to-splunk-by-fluentd).
+alternative to Splunk, see the article
+["Free Alternative to Splunk Using Fluentd"](/guides/free-alternative-to-splunk-by-fluentd.md).
 
 
 ## Installing the requisites

--- a/install/post-installation-guide.md
+++ b/install/post-installation-guide.md
@@ -32,7 +32,8 @@ By default, td-agent writes its operation logs to the following file:
 /var/log/td-agent/td-agent.log
 ```
 
-If you want to make td-agent more verbose, read the article ["Trouble Shooting"](trouble-shooting).
+If you want to make td-agent more verbose, read the article
+["Trouble Shooting"](/deployment/trouble-shooting.md).
 
 
 ## Connect to Other Services

--- a/overview/quickstart.md
+++ b/overview/quickstart.md
@@ -2,7 +2,7 @@
 
 Let's get started with **Fluentd**! **Fluentd** is a fully free and
 fully open-source log collector that instantly enables you to have a
-'**Log Everything**' architecture with [125+ types of systems](http://fluentd.org/plugin/).
+'**Log Everything**' architecture with [125+ types of systems](https://fluentd.org/plugin/).
 
 ![](/images/fluentd-architecture.png)
 

--- a/plugins/input/http.md
+++ b/plugins/input/http.md
@@ -228,7 +228,7 @@ $ curl -X POST -d '123456:awesome' http://localhost:9880/app.log
 ```
 
 Many other formats (e.g. csv/syslog/nginx) are also supported as well.
-You can find the full list of supported formats in ["Parser Plugin Overview"](parser-plugin-overview).
+You can find the full list of supported formats in ["Parser Plugin Overview"](/plugins/parsers/README.md).
 
 Note that parser plugins do not support [the batch mode](#handle-large-data-with-batch-mode). So if you want to use bulk
 insertion for handling a large data set, please consider to keep using

--- a/plugins/output/webhdfs.md
+++ b/plugins/output/webhdfs.md
@@ -63,7 +63,8 @@ cluster.
 </match>
 ```
 
-Please see the [Fluentd + HDFS: Instant Big Data Collection](http-to-hdfs) article for real-world use cases.
+Please see the [Fluentd + HDFS: Instant Big Data Collection](/guides/http-to-hdfs.md)
+article for real-world use cases.
 
 Please see the [Config File](/configuration/config-file.md) article for the basic
 structure and syntax of the configuration file. For `<buffer>` section,


### PR DESCRIPTION
These internal links were broken due to the migration to GitBook.

Also, let's prefer HTTPS over HTTP whenever possible.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>