### PR TITLE
Add .gitbook.yaml to navigate users from /v1.0/articles/quickstart

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,8 @@
+root: ./
+
+structure:
+  readme: README.md
+  summary: SUMMARY.md
+
+redirects:
+  v1.0/articles/quickstart: README.md


### PR DESCRIPTION
Previously, the index page of the documentation was hosted at:

    https://docs.fluentd.org/v1.0/articles/quickstart

The problem is that, due to the migration to GitBook, no page
exists at that URL anymore. Still, Google and others are showing
results that point to the URL.

In order to solve this issue, I added .gitbook.yaml, which should
redirect users who access to /v1.0/articles/quickstart to the
current index page.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>