### PR TITLE
add additonal redirect

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -6,4 +6,4 @@ structure:
 
 redirects:
   v1.0/articles/quickstart: README.md
-  v1.0/articles/quickstart: guides/apache-to-mongo.md
+  v1.0/articles/apache-to-mongo: guides/apache-to-mongo.md

--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -6,3 +6,4 @@ structure:
 
 redirects:
   v1.0/articles/quickstart: README.md
+  v1.0/articles/quickstart: guides/apache-to-mongo.md


### PR DESCRIPTION
Signed-off-by: jordo1138 <8525512+jordo1138@users.noreply.github.com>
see #27 , just a test example to do the redirects from your existing .gitbook.yaml , seems like most v1 articles follow ```v1.0/articles/name-of-guide``` and then redirect to ```guides/name-of-guide.md``` 
if the guide exists in /guides in the repo...actual guides uri is ```how-to-guides```
additional seo redirects could be done also as mentioned

<img width="842" alt="Screen Shot 2019-05-21 at 10 59 13 PM" src="https://user-images.githubusercontent.com/8525512/58154060-8ba52180-7c25-11e9-9432-f31dd3729136.png">
