### PR TITLE
Module name needs to be included for TimeParser

### DIFF
--- a/developer/api-plugin-parser.md
+++ b/developer/api-plugin-parser.md
@@ -46,7 +46,7 @@ module Fluent::Plugin
 
       # TimeParser class is already given. It takes a single argument as the time format
       # to parse the time string with.
-      @time_parser = TimeParser.new(@time_format)
+      @time_parser = Fluent::TimeParser.new(@time_format)
     end
 
     def parse(text)


### PR DESCRIPTION
```
root@xxxxx:/var/log/td-agent# /opt/td-agent/embedded/bin/fluentd --log /var/log/td-agent/td-agent.log --daemon /var/run/td-agent/td-agent.pid $TD_AGENT_OPTIONS
/etc/td-agent/plugin/parser_xxx.rb:16:in `configure': uninitialized constant Fluent::Plugin::XXX::TimeParser (NameError)
Did you mean?  Fluent::TimeParser
```