### PR TITLE
overview: add a missing article "td-agent v2 vs v3"

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,6 +6,7 @@
   * [Support](/overview/support.md)
   * [FAQ](/overview/faq.md)
   * [Logo](/overview/logo.md)
+  * [td-agent v2 vs v3](/overview/td-agent-v2-vs-v3.md)
 
 * [Installation]()
   * [Before Installation](/install/before-install.md)

--- a/overview/td-agent-v2-vs-v3.md
+++ b/overview/td-agent-v2-vs-v3.md
@@ -1,0 +1,51 @@
+# td-agent v2 vs. td-agent v3
+
+## Supported Platforms
+
+[Treasure Data, Inc.](https://www.treasuredata.com) maintains stable packages
+for Fluentd and canonical plugins as Treasure Agent (the package is called
+`td-agent`). td-agent has v2 and v3. td-agent v2 for the production and v3 is
+the new stable version for working with ruby 2.4 and fluetnd v1 series.
+
+
+|  Platform         | v2 | v3 |
+| ----------------- | -- | -- |
+| RedHat/CentOS 5   | OK |    |
+| RedHat/CentOS 6/7 | OK | OK |
+| Ubuntu Precise    | OK |    |
+| Ubuntu Trusty     | OK | OK |
+| Ubuntu Xenial     | OK | OK |
+| Ubuntu Bionic     | OK | OK |
+| Debian Wheezy     | OK |    |
+| Debian Jessie     | OK | OK |
+| Debian Stretch    | OK | OK |
+| MacOSX            | OK | OK |
+| Windows           |    | OK |
+
+## Features
+
+Major feature updates to td-agent v3 are as follows.
+
+- Ruby 2.4
+- Fluentd v1
+- Updated for the core libraries, msgpack, Cool.io, etc.
+- Windows support
+- Drop older distributions and non-popular plugins
+- Remove fluentd-ui. This will be released as separated td-agent-ui package
+
+## td-agent v3 is now stable version
+
+Fluentd v1 is the new stable version.
+
+## How to Install
+
+* [Ubuntu/Debian](/install/install-by-deb.md)
+* [RedHat/CentOS](/install/install-by-rpm.md)
+* [Windows](/install/install-by-msi.md)
+* [macOS](/install/install-by-dmg.md)
+* [rubygems](/install/install-by-gem.md)
+
+------------------------------------------------------------------------
+
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open).
+[Fluentd](http://www.fluentd.org/) is a open source project under [Cloud Native Computing Foundation (CNCF)](https://cncf.io/). All components are available under the Apache 2 License.


### PR DESCRIPTION
While updating the redirection mapping, I noticed the article is
missing from the new site.

Let's migrate it from the old doc repository.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>