### PR TITLE
Add the redirect definition for "overview/td-agent-v2-vs-v3.md"

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -13,6 +13,7 @@ redirects:
   v1.0/articles/life-of-a-fluentd-event: overview/life-of-a-fluentd-event.md
   v1.0/articles/logo: overview/logo.md
   v1.0/articles/faq: overview/faq.md
+  v1.0/articles/td-agent-v2-vs-v3: overview/td-agent-v2-vs-v3.md
 
   # Install
   v1.0/articles/install-by-dmg: install/install-by-dmg.md


### PR DESCRIPTION
This article was added in 009771c, and was not on the list yet.
This patch should fix it.

Signed-off-by: Fujimoto Seiji <fujimoto@clear-code.com>