### PR TITLE
update image markdown link to make it show in website

### DIFF
--- a/plugins/buffer/README.md
+++ b/plugins/buffer/README.md
@@ -39,11 +39,7 @@ where chunks wait before the transportation. Every newly-created chunk
 starts from *stage*, then proceeds to *queue* in time (and subsequently
 gets transferred to the destination).
 
-<div>
-
 [![](/images/fluentd-v0.14-plugin-api-overview.png)](/images/fluentd-v0.14-plugin-api-overview.png)
-
-</div>
 
 
 ## Control Retry Behaviour


### PR DESCRIPTION
the image is not show up in webpage https://docs.fluentd.org/buffer
This PR try to fix it

![image](https://user-images.githubusercontent.com/85204/60317652-90868f00-99a2-11e9-9f10-f5ec5756a70f.png)
