### PR TITLE
Fix link to "Fluentd Architecture": add https

### DIFF
--- a/guides/free-alternative-to-splunk-by-fluentd.md
+++ b/guides/free-alternative-to-splunk-by-fluentd.md
@@ -230,7 +230,7 @@ buffer, etc.) according to your needs.
 
 ## Learn More
 
--   [Fluentd Architecture](//www.fluentd.org/architecture)
+-   [Fluentd Architecture](https://www.fluentd.org/architecture)
 -   [Fluentd Get Started](/overview/quickstart.md)
 -   [Downloading Fluentd](http://www.fluentd.org/download)
 


### PR DESCRIPTION
Fix for #56 .
Before, we were being redirected to
https://github.com/fluent/fluentd-docs-gitbook/tree/159b4cb7cc0f9e0d33d3a3abbc13754c2c8ee64d/www.fluentd.org/architecture/README.md

Signed-off-by: Greg Harmon <gharm@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluent/fluentd-docs-gitbook/61)
<!-- Reviewable:end -->