### PR TITLE
Correct config for tls_client_cert_path

### DIFF
--- a/plugins/output/forward.md
+++ b/plugins/output/forward.md
@@ -372,7 +372,7 @@ Verify hostname of servers and certificates or not in TLS transport.
 
 The additional CA certificate path for TLS.
 
-### tls\_client\_cert\_pat
+### tls\_client\_cert\_path
 
 | type   | default | version |
 |:------:|:-------:|:-------:|


### PR DESCRIPTION
there is a small typo: `tls_client_cert_pat` is `tls_client_cert_path`