### PR TITLE
Add https to all www.fluentd.org link

### DIFF
--- a/guides/apache-to-mongodb.md
+++ b/guides/apache-to-mongodb.md
@@ -178,7 +178,7 @@ robust.
 
 ## Learn More
 
--   [Fluentd Architecture](//www.fluentd.org/architecture)
+-   [Fluentd Architecture](https://www.fluentd.org/architecture)
 -   [Fluentd Get Started](/overview/quickstart.md)
 -   [MongoDB Output Plugin](/plugins/output/mongo.md)
 -   [MongoDB ReplicaSet Output Plugin](/plugins/output/mongo_replset.md)

--- a/guides/apache-to-s3.md
+++ b/guides/apache-to-s3.md
@@ -146,7 +146,7 @@ Fluentd + Amazon S3 makes real-time log archiving simple.
 
 ## Learn More
 
--   [Fluentd Architecture](//www.fluentd.org/architecture)
+-   [Fluentd Architecture](https://www.fluentd.org/architecture)
 -   [Fluentd Get Started](/overview/quickstart.md)
 -   [Amazon S3 Output plugin](/plugins/output/s3.md)
 

--- a/guides/free-alternative-to-splunk-by-fluentd.md
+++ b/guides/free-alternative-to-splunk-by-fluentd.md
@@ -230,7 +230,7 @@ buffer, etc.) according to your needs.
 
 ## Learn More
 
--   [Fluentd Architecture](//www.fluentd.org/architecture)
+-   [Fluentd Architecture](https://www.fluentd.org/architecture)
 -   [Fluentd Get Started](/overview/quickstart.md)
 -   [Downloading Fluentd](http://www.fluentd.org/download)
 

--- a/guides/http-to-hdfs.md
+++ b/guides/http-to-hdfs.md
@@ -159,7 +159,7 @@ major problems for several months now.
 
 ## Learn More
 
--   [Fluentd Architecture](//www.fluentd.org/architecture)
+-   [Fluentd Architecture](https://www.fluentd.org/architecture)
 -   [Fluentd Get Started](/overview/quickstart.md)
 -   [WebHDFS Output Plugin](/plugins/output/webhdfs.md)
 -   [Slides: Fluentd and WebHDFS](http://www.slideshare.net/tagomoris/fluentd-and-webhdfs)

--- a/guides/http-to-td.md
+++ b/guides/http-to-td.md
@@ -157,7 +157,7 @@ analytics infrastructure.
 
 ## Learn More
 
--   [Fluentd Architecture](//www.fluentd.org/architecture)
+-   [Fluentd Architecture](https://www.fluentd.org/architecture)
 -   [Fluentd Get Started](/overview/quickstart.md)
 -   [Treasure Data](http://www.fluentd.org/treasuredata)
 -   [Treasure Data: Documentation](http://docs.treasuredata.com/)

--- a/guides/kinesis-stream.md
+++ b/guides/kinesis-stream.md
@@ -202,7 +202,7 @@ and robust.
 
 ## Learn More
 
--   [Fluentd Architecture](//www.fluentd.org/architecture)
+-   [Fluentd Architecture](https://www.fluentd.org/architecture)
 -   [Fluentd Get Started](/overview/quickstart.md)
 -   [Amazon Kinesis](https://aws.amazon.com/kinesis/)
 -   [Amazon Kinesis Output Plugin](https://github.com/awslabs/aws-fluent-plugin-kinesis) (Made by Amazon Web Services)

--- a/install/install-by-deb.md
+++ b/install/install-by-deb.md
@@ -14,7 +14,7 @@ and operating a Ruby daemon.
 That's why [Treasure Data, Inc](http://www.treasuredata.com/) is
 providing **the stable distribution of Fluentd**, called `td-agent`. The
 differences between Fluentd and td-agent can be found
-[here](//www.fluentd.org/faqs).
+[here](https://www.fluentd.org/faqs).
 
 This installation guide is for td-agent v3, the new stable version.
 td-agent v3 uses fluentd v1.0 in the core. See [this page](/overview/td-agent-v2-vs-v3.md) for the comparison between v2 and v3.

--- a/install/install-by-rpm.md
+++ b/install/install-by-rpm.md
@@ -14,7 +14,7 @@ and operating a Ruby daemon.
 That's why [Treasure Data, Inc](http://www.treasuredata.com/) is
 providing **the stable distribution of Fluentd**, called `td-agent`. The
 differences between Fluentd and td-agent can be found
-[here](//www.fluentd.org/faqs).
+[here](https://www.fluentd.org/faqs).
 
 This installation guide is for td-agent v3, the new stable version.
 td-agent v3 uses fluentd v1.0 in the core. See [this page](/overview/td-agent-v2-vs-v3.md) for the comparison between v2 and v3.


### PR DESCRIPTION
It seems necessary to add `https:` to www.fluentd.org link.

To fix https://github.com/fluent/fluentd-docs-gitbook/issues/65

cc @repeatedly 