### PR TITLE
Added code block around embedding Ruby match example

### DIFF
--- a/configuration/config-file.md
+++ b/configuration/config-file.md
@@ -478,9 +478,11 @@ for the reason explained above.
 Since Fluentd v1.4.0, you can use `#{...}` to embed arbitrary Ruby code
 into match patterns. Here is an example.
 
-    <match "app.#{ENV['FLUENTD_TAG']}">
-      @type stdout
-    </match>
+```
+<match "app.#{ENV['FLUENTD_TAG']}">
+  @type stdout
+</match>
+```
 
 If you set the environment variable `FLUENTD_TAG` to `dev`, this
 evaluates to `app.dev`.


### PR DESCRIPTION
- There were no code block backticks around example code, which was causing it to not display correctly in the docs.