### PR TITLE
Make :udp a symbol

### DIFF
--- a/developer/api-config-types.md
+++ b/developer/api-config-types.md
@@ -256,7 +256,7 @@ does not exist in the list, error will occur on boot.
 Code Example:
 
 ```
-config_param :protocol_type, :enum, list: [:udp, :tcp], default: udp
+config_param :protocol_type, :enum, list: [:udp, :tcp], default: :udp
 
 def send
   case @protocol_type


### PR DESCRIPTION
`default: :udp` instead of `default: udp` - which would fail with `NameError (undefined local variable or method 'udp' for main:Object)`