### PR TITLE
Fix parameter name of default value

### DIFF
--- a/configuration/buffer-section.md
+++ b/configuration/buffer-section.md
@@ -387,7 +387,7 @@ These parameters below are to configure buffer plugins and its chunks.
     -   The percentage of chunk size threshold for flushing
     -   output plugin will flush the chunk when actual size reaches `chunk_limit_size * chunk_full_threshold (== 8MB * 0.95 in default)`
 -   `queued_chunks_limit_size` \[integer\] (since v1.1.3)
-    -   Default: 1 (equals to the same value as the `flush_interval` parameter)
+    -   Default: 1 (equals to the same value as the `flush_thread_count` parameter)
     -   Limit the number of queued chunks.
     -   If you set smaller flush\_interval, e.g. 1s, there are lots of small queued chunks in buffer. This is not good with file buffer because it consumes lots of fd resources when output destination has a problem. This parameter mitigates such situations.
 -   `compress` \[enum: text/gzip\]


### PR DESCRIPTION
This PR fixes the wrong parameter name of queued_chunks_limit_size's default value.