### PR TITLE
Added required bracket back

### DIFF
--- a/plugins/filter/parser.md
+++ b/plugins/filter/parser.md
@@ -14,7 +14,7 @@ mutates its event record with parsed result.
   key_name log
   <parse>
     @type regexp
-    expression /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)$/
+    expression /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)$/
     time_format %d/%b/%Y:%H:%M:%S %z
   </parse>
 </filter>


### PR DESCRIPTION
This was removed in https://github.com/fluent/fluentd-docs-gitbook/pull/95 but that is incorrect.

The second bracket is required because the first `]` is escaped with `\` because the regex is looking for the next `]` before the `time` attribute is set. The second is what closes the character class.

The example the message is trying to parse is 

>[05/Feb/2018:12:00:00 +0900]

So this: `\[(?<time>[^\]*)\]` is invalid because there are two `[` and one `]` **and** one literal `]`

See this [original](https://fluentular.herokuapp.com/parse?regexp=%5E%28%3F%3Chost%3E%5B%5E+%5D*%29+%5B%5E+%5D*+%28%3F%3Cuser%3E%5B%5E+%5D*%29+%5C%5B%28%3F%3Ctime%3E%5B%5E%5C%5D*%29%5C%5D+%22%28%3F%3Cmethod%3E%5CS%2B%29%28%3F%3A+%2B%28%3F%3Cpath%3E%5B%5E+%5D*%29+%2B%5CS*%29%3F%22+%28%3F%3Ccode%3E%5B%5E+%5D*%29+%28%3F%3Csize%3E%5B%5E+%5D*%29%24&input=192.168.0.1+-+-+%5B05%2FFeb%2F2018%3A12%3A00%3A00+%2B0900%5D+%22GET+%2F+HTTP%2F1.1%22+200+777&time_format=%25d%2F%25b%2F%25Y%3A%25H%3A%25M%3A%25S+%25z) and this [fixed](https://fluentular.herokuapp.com/parse?regexp=%5E%28%3F%3Chost%3E%5B%5E+%5D*%29+%5B%5E+%5D*+%28%3F%3Cuser%3E%5B%5E+%5D*%29+%5C%5B%28%3F%3Ctime%3E%5B%5E%5C%5D%5D*%29%5C%5D+%22%28%3F%3Cmethod%3E%5CS%2B%29%28%3F%3A+%2B%28%3F%3Cpath%3E%5B%5E+%5D*%29+%2B%5CS*%29%3F%22+%28%3F%3Ccode%3E%5B%5E+%5D*%29+%28%3F%3Csize%3E%5B%5E+%5D*%29%24&input=192.168.0.1+-+-+%5B05%2FFeb%2F2018%3A12%3A00%3A00+%2B0900%5D+%22GET+%2F+HTTP%2F1.1%22+200+777&time_format=%25d%2F%25b%2F%25Y%3A%25H%3A%25M%3A%25S+%25z)