### PR TITLE
Change fluent-plugin-prometheus version to 1.6.1

### DIFF
--- a/deployment/monitoring-prometheus.md
+++ b/deployment/monitoring-prometheus.md
@@ -12,13 +12,13 @@ recommending to use Prometheus by default to monitor Fluentd.
 First of all, please install `fluent-plugin-prometheus` gem.
 
 ```
-$ fluent-gem install fluent-plugin-prometheus --version='~>1.0.0'
+$ fluent-gem install fluent-plugin-prometheus --version='~>1.6.1'
 ```
 
 If you are using td-agent, use `td-agent-gem` for installation.
 
 ```
-$ sudo td-agent-gem install fluent-plugin-prometheus --version='~>1.0.0'
+$ sudo td-agent-gem install fluent-plugin-prometheus --version='~>1.6.1'
 ```
 
 [This GitHub repository](https://github.com/kzk/fluentd-prometheus-config-example)


### PR DESCRIPTION
The version installed by the command has been verified as version 1.0.1.  
(in fluent/fluentd:edge Container) But Version 1.0.1 gives the error as   `invalid argument`.
**If specify version 1.0.0 as 1.6.1, no error occurs.**  
The same issue has been reported in [this repository](https://github.com/fluent/fluentd-kubernetes-daemonset/issues/361).

tested in Windows 10 Pro(1903, 18362.476 Build) / DockerDesktop( 2.1.0.5 version)
