### PR TITLE
fix some links 

### DIFF
--- a/configuration/buffer-section.md
+++ b/configuration/buffer-section.md
@@ -381,7 +381,7 @@ These parameters below are to configure buffer plugins and its chunks.
 -   `queue_limit_length` \[integer\]
     -   Default: nil
     -   The queue length limitation of this buffer plugin instance
-    -   This parameter is for [v0.12 compatibility](/plugin-helper-overview/api-plugin-helper-compat_parameters.md). Use `total_limit_size` instead for v1 configuration.
+    -   This parameter is for [v0.12 compatibility](/developer/api-plugin-helper-compat_parameters.md). Use `total_limit_size` instead for v1 configuration.
 -   `chunk_full_threshold` \[float\]
     -   Default: 0.95
     -   The percentage of chunk size threshold for flushing

--- a/configuration/parse-section.md
+++ b/configuration/parse-section.md
@@ -77,7 +77,7 @@ plugins.
     -   example: `types user_id:integer,paid:bool,paid_usd_amount:float`
 -   **time\_key** (string) (optional): Specify time field for event time. If the event doesn't have this field, current time is used.
     -   Default: `nil`
-    -   Note that [json](/plugins/parser/json), [ltsv](/plugins/parser/ltsv) and [regexp](/plugins/parser/regexp) override the default value of this parameter and set it to `time` by default.
+    -   Note that [json](/plugins/parser/json.md), [ltsv](/plugins/parser/ltsv.md) and [regexp](/plugins/parser/regexp.md) override the default value of this parameter and set it to `time` by default.
 -   **null\_value\_pattern** (string) (optional): Specify null value pattern.
     -   Default: `nil`
 -   **null\_empty\_string** (bool) (optional): If `true`, empty string field is replaced with `nil`.


### PR DESCRIPTION
I fixed some broken links.

* `v0.12 compatibility` of https://docs.fluentd.org/configuration/buffer-section
* `json, ltsv and regexp` of https://docs.fluentd.org/configuration/parse-section