### PR TITLE
add branches links to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@ This repository is for https://docs.fluentd.org/ by gitbook.
 
 Here are two branches:
 
-- 1.0: For fluentd v1 document: https://docs.fluentd.org/v/1.0/
-- 0.12: For old fluentd v0.12 document: https://docs.fluentd.org/v/0.12/
+- 1.0: For fluentd v1 document: https://github.com/fluent/fluentd-docs-gitbook/tree/1.0 | https://docs.fluentd.org/v/1.0/
+- 0.12: For old fluentd v0.12 document: https://github.com/fluent/fluentd-docs-gitbook/tree/0.12 | https://docs.fluentd.org/v/0.12/


### PR DESCRIPTION
Gitbook is having issues. and it took me a while to figure out the docs were available in this repo just under their fluentd version tag https://github.com/fluent/fluentd-docs-gitbook/issues/149

This PR adds the link to the revisions alongside the gitbook link