### PR TITLE
update gem install doc to reflect Ruby 2.4 support

### DIFF
--- a/install/install-by-gem.md
+++ b/install/install-by-gem.md
@@ -11,7 +11,7 @@ your OS properly. This will prevent many unnecessary problems.
 
 ## Step 1: Install Ruby interpreter
 
-Please install Ruby \>= 2.1 on your local environment. In addition,
+Please install Ruby \>= 2.4 on your local environment. In addition,
 install ruby-dev package via package manager to build native extension
 gems.
 


### PR DESCRIPTION
Signed-off-by: Christian Lacsina <christian.lacsina@rx-m.com>

Ruby Gem installation docs still list Ruby 2.1 as the minimum version. Minimum version is now Ruby 2.4 according to https://www.fluentd.org/blog/drop-schedule-announcement-in-2019