### PR TITLE
Fix geoip code example

### DIFF
--- a/plugins/filter/geoip.md
+++ b/plugins/filter/geoip.md
@@ -176,7 +176,7 @@ fluent-plugin-elasticsearch
     country_code ${country.iso_code["host"]}
     country_name ${country.names.en["host"]}
   </record>
-</match>
+</filter>
 
 <match apache.access>
   @type           elasticsearch


### PR DESCRIPTION
I noticed that, the code example in `https://docs.fluentd.org/filter/geoip` about the use case of `country_code` starts with a `<filter>` tag but closes with `</match>` tag.