### PR TITLE
update config examples to use out_forward instead of in_forward in service discovery 

### DIFF
--- a/plugins/service_discovery/file.md
+++ b/plugins/service_discovery/file.md
@@ -9,7 +9,7 @@ This is the exmple with out_forward.
 It udpates targets to send data by out_forward.
 
 ```
-<source>
+<match pattern>
   @type forward
 
   <service_discovery>

--- a/plugins/service_discovery/srv.md
+++ b/plugins/service_discovery/srv.md
@@ -8,7 +8,7 @@ This is an exmple with out\_forward.
 It udpates targets to get SRV record from `_fluentd._tcp.exmaple.com`.
 
 ```
-<source>
+<match pattern>
   @type forward
 
   <service_discovery>


### PR DESCRIPTION
configuration examples in service discovery examples use in_forward; update to out_forward