### PR TITLE
Fix  typo

### DIFF
--- a/plugins/service_discovery/file.md
+++ b/plugins/service_discovery/file.md
@@ -5,8 +5,8 @@ YAML and JSON are allowed as the file formats.
 
 ## Example Configuration
 
-This is the exmple with out_forward.
-It udpates targets to send data by out_forward.
+This is the example with out_forward.
+It updates targets to send data by out_forward.
 
 ```
 <match pattern>

--- a/plugins/service_discovery/srv.md
+++ b/plugins/service_discovery/srv.md
@@ -4,8 +4,8 @@ The `srv` serivce discovery plugin updates targets by [SRV Record](https://tools
 
 ## Example Configuration
 
-This is an exmple with out\_forward.
-It udpates targets to get SRV record from `_fluentd._tcp.exmaple.com`.
+This is an example with out\_forward.
+It updates targets to get SRV record from `_fluentd._tcp.exmaple.com`.
 
 ```
 <match pattern>

--- a/plugins/service_discovery/static.md
+++ b/plugins/service_discovery/static.md
@@ -4,7 +4,7 @@ The `static` service discovery plugin set the list of targets.
 
 ## Example Configuration
 
-This is the exmple with out_forward.
+This is the example with out_forward.
 It defines the list of targets. it is similer to the server directive in out_forward.
 
 ```


### PR DESCRIPTION
I fixed typo

- `exmple` -> `example`
- `udpates` -> `updates`