### PR TITLE
rpc require fluentd start not with --no-supervisor

### DIFF
--- a/deployment/rpc.md
+++ b/deployment/rpc.md
@@ -4,8 +4,7 @@ HTTP RPC enables you to manage your Fluentd instance through HTTP
 endpoints. You can use this feature as a replacement of [Unix signals](/deployment/signals.md).
 
 It is especially useful for environments where signals are not supported well
-e.g. Windows.
-
+e.g. Windows. This requires Fluentd to start not with --no-supervisor command-line option.
 
 ## Configuration
 


### PR DESCRIPTION
I found if config fluentd with --no-supervisor, rpc flunction will failed