### PR TITLE
Updates: Image Descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Introduction
 
-![Fluentd Docs Image](.gitbook/assets/images/logo_documentation_1.0.png)
+![](.gitbook/assets/images/logo_documentation_1.0.png)
 
-[Fluentd](https://www.fluentd.org/) is an open source data collector for unified logging layer. Fluentd allows you to unify data collection and consumption for a better use and understanding of data.
+[Fluentd](https://www.fluentd.org/) is an open-source data collector for unified
+logging layer. Fluentd allows you to unify data collection and consumption for a
+better use and understanding of data.
 
-[Fluentd](https://www.fluentd.org/) is licensed under the terms of the [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0). This project is made and sponsored by [Treasure Data](https://www.treasuredata.com).
+[Fluentd](https://www.fluentd.org/) is licensed under the terms of the
+[Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0). This project
+is made and sponsored by [Treasure Data](https://www.treasuredata.com).

--- a/container-deployment/docker-logging-driver.md
+++ b/container-deployment/docker-logging-driver.md
@@ -100,7 +100,7 @@ By default, the Fluentd logging driver will try to find a local Fluentd instance
 (Step # 2) listening for connections on the TCP port `24224`. Note that the
 container will not start if it cannot connect to the Fluentd instance.
 
-![fluentd_docker_integrated.png](https://www.fluentd.org/assets/img/recipes/fluentd_docker_integrated.png)
+![Integration of Docker with Fluentd](https://www.fluentd.org/assets/img/recipes/fluentd_docker_integrated.png)
 
 The following command will run a base Ubuntu container and print some messages
 to the standard output:

--- a/container-deployment/kubernetes.md
+++ b/container-deployment/kubernetes.md
@@ -1,6 +1,6 @@
 # Kubernetes Logging with Fluentd
 
-![fluentd_kubernetes.png](/images/fluentd_kubernetes.png)
+![Fluentd + Kubernetes](/images/fluentd_kubernetes.png)
 
 [Kubernetes](http://kubernetes.io) provides two logging endpoints for
 applications and cluster logs:

--- a/deployment/fluentd-ui.md
+++ b/deployment/fluentd-ui.md
@@ -44,7 +44,7 @@ The default account credentials are:
 -   `username="admin"`
 -   `password="changeme"`
 
-![fluentd-ui.gif](/images/fluentd-ui/fluentd-ui.gif)
+![Fluentd UI](/images/fluentd-ui/fluentd-ui.gif)
 
 
 ## Screenshots
@@ -54,26 +54,32 @@ The default account credentials are:
 
 ### Dashboard
 
-![dashboard.gif](/images/fluentd-ui/dashboard.gif)
+![Fluentd UI: Dashboard](/images/fluentd-ui/dashboard.gif)
 
 
 ### Setting
 
-![setting.git](/images/fluentd-ui/setting.gif)
+![Fluentd UI: Settings](/images/fluentd-ui/setting.gif)
 
 
 ### `in_tail` setting
 
-![`in_tail`.gif](/images/fluentd-ui/in_tail.gif)
+![Fluentd UI: `in_tail` Settings](/images/fluentd-ui/in_tail.gif)
 
 
 ### Plugin
 
-![plugin.gif](/images/fluentd-ui/plugin.gif)
+![Plugin](/images/fluentd-ui/plugin.gif)
 
-![ss01](/images/fluentd-ui/01.png) ![ss02](/images/fluentd-ui/02.png)
-![ss03](/images/fluentd-ui/03.png) ![ss04](/images/fluentd-ui/04.png)
-![ss05](/images/fluentd-ui/05.png)
+![](/images/fluentd-ui/01.png)
+
+![](/images/fluentd-ui/02.png)
+
+![](/images/fluentd-ui/03.png)
+
+![](/images/fluentd-ui/04.png)
+
+![](/images/fluentd-ui/05.png)
 
 
 ------------------------------------------------------------------------

--- a/deployment/high-availability.md
+++ b/deployment/high-availability.md
@@ -39,7 +39,7 @@ describe how to set up Fluentd's topology for high-availability.
 To configure Fluentd for high-availability, we assume that your network
 consists of **log forwarders** and **log aggregators**.
 
-![fluentd_ha.png](/images/fluentd_ha.png)
+![Fluentd's High-Availability Overview](/images/fluentd_ha.png)
 
 '**log forwarders**' are typically installed on every node to receive
 local events. Once an event is received, they forward it to the 'log

--- a/deployment/monitoring-prometheus.md
+++ b/deployment/monitoring-prometheus.md
@@ -205,7 +205,7 @@ Now, open this URL `http://localhost:9090/` in your browser.
 Go to `http://localhost:9090/targets` to see the list of Fluentd nodes and their
 status.
 
-![prometheus-targets.png](/images/prometheus-targets.png)
+![Prometheus Targets](/images/prometheus-targets.png)
 
 
 ### List of Fluentd Metrics
@@ -213,7 +213,7 @@ status.
 Visit `http://localhost:9090/graph` to explore Fluentd's internal metrics.
 You'll see eight (8) metrics in the metric list:
 
-![prometheus-metrics.png](/images/prometheus-metrics.png)
+![Prometheus Metrics](/images/prometheus-metrics.png)
 
 -   `fluentd_input_status_num_records_total`
 -   `fluentd_output_status_buffer_queue_length`
@@ -227,7 +227,7 @@ You'll see eight (8) metrics in the metric list:
 Pick `fluentd_input_status_num_records_total` and you'll see the total incoming
 records per tag.
 
-![prometheus-graph.png](/images/prometheus-graph.png)
+![Prometheus Graph](/images/prometheus-graph.png)
 
 
 ### Example Prometheus Queries
@@ -292,7 +292,7 @@ For more advanced visualization and alerting, we recommend
 
 -   [Grafana Support for Prometheus](https://prometheus.io/docs/visualization/grafana/)
 
-![prometheus-grafana.png](/images/prometheus-grafana.png)
+![Prometheus + Grafana](/images/prometheus-grafana.png)
 
 
 ## Further Readings

--- a/deployment/multi-process-workers.md
+++ b/deployment/multi-process-workers.md
@@ -17,7 +17,7 @@ Multi process workers feature launches multiple workers and use a separate
 process per worker. In addition, `fluentd` provides several features for multi
 process workers, so you can get multi process merits.
 
-![multi-process-workers.png](/images/multi-process-workers.png)
+![Multi-process Workers](/images/multi-process-workers.png)
 
 
 ## Configuration

--- a/guides/apache-to-minio.md
+++ b/guides/apache-to-minio.md
@@ -96,7 +96,7 @@ Wait until the data gets flushed from the buffer (you can adjust the
 flush interval using the `timekey` and `timekey_wait` options above).
 Then you will see the aggregated log data on Minio:
 
-![minio-screenshot.png](/images/minio-screenshot.png)
+![Minio](/images/minio-screenshot.png)
 
 
 ## Learn More

--- a/guides/apache-to-mongodb.md
+++ b/guides/apache-to-mongodb.md
@@ -26,7 +26,7 @@ import Apache logs into MongoDB.
 
 The figure below shows how things will work:
 
-![apache-to-mongodb.png](/images/apache-to-mongodb.png)
+![Apache + MongoDB](/images/apache-to-mongodb.png)
 
 Fluentd does three (3) things:
 

--- a/guides/cep-norikra.md
+++ b/guides/cep-norikra.md
@@ -39,7 +39,7 @@ create a robust stream data processing platform.
 
 The figure below shows the high-level architecture:
 
-![fluentd-norikra-overview.png](/images/fluentd-norikra-overview.png)
+![Fluentd + Norikra Overview](/images/fluentd-norikra-overview.png)
 
 
 ## Installation

--- a/guides/free-alternative-to-splunk-by-fluentd.md
+++ b/guides/free-alternative-to-splunk-by-fluentd.md
@@ -5,7 +5,7 @@ its high cost makes it prohibitive for many teams. In this article, we
 present a free and open source alternative to Splunk by combining three
 open source projects: Elasticsearch, Kibana, and Fluentd.
 
-![kibana6-screenshot-visualize.png](/images/kibana6-screenshot-visualize.png)
+![Kibana Visualization](/images/kibana6-screenshot-visualize.png)
 
 
 [Elasticsearch](https://www.elastic.co/products/elasticsearch) is an
@@ -18,7 +18,7 @@ By combining these three tools (Fluentd + Elasticsearch + Kibana) we get
 a scalable, flexible, easy to use log search engine with a great Web UI
 that provides an open-source Splunk alternative, all for free.
 
-![fluentd-elasticsearch-kibana.png](/images/fluentd-elasticsearch-kibana.png)
+![Fluentd + Elasticsearch + Kibana](/images/fluentd-elasticsearch-kibana.png)
 
 
 In this guide, we will go over installation, setup, and basic use of
@@ -176,7 +176,7 @@ Kibana.
 For starters, let's access `http://localhost:5601` and click the `Set
 up index patters` button in the upper-right corner of the screen.
 
-![kibana6-screenshot-topmenu.png](/images/kibana6-screenshot-topmenu.png)
+![Kibana Top Menu](/images/kibana6-screenshot-topmenu.png)
 
 Kibana will start a wizard that guides you through configuring the data
 sets to visualize. If you want a quick start, use `logstash-*` as the
@@ -185,7 +185,7 @@ index pattern, and select `@timestamp` as the time-filter field.
 After setting up an index pattern, you can view the system logs as they
 flow in:
 
-![kibana6-screenshot.png](/images/kibana6-screenshot.png)
+![Kibana: Discover](/images/kibana6-screenshot.png)
 
 For more detail on how to use Kibana, please read the official
 [manual](https://www.elastic.co/guide/en/kibana/current/index.html).

--- a/guides/graylog2.md
+++ b/guides/graylog2.md
@@ -87,7 +87,7 @@ Then, from the dropdown, choose `GELF UDP` and click on `Launch new input`,
 which should pop up a modal dialogue, Select the `Node` and fill the `Title`.
 Then, click `Save`.
 
-![graylog2-input.png](/images/graylog2-input.png)
+![Graylog Inputs](/images/graylog2-input.png)
 
 Now, Graylog2 is ready to accept messages from Fluentd over UDP. It's time to
 configure Fluentd.
@@ -153,7 +153,7 @@ $ sudo systemctl restart td-agent
 When you log back into Graylog, you should be seeing a graph like this
 (wait for events to flow in):
 
-![graylog2-graph.png](/images/graylog2-graph.png)
+![Graylog Graph](/images/graylog2-graph.png)
 
 ------------------------------------------------------------------------
 

--- a/guides/http-to-hdfs.md
+++ b/guides/http-to-hdfs.md
@@ -25,7 +25,7 @@ receive data from HTTP and stream it into HDFS.
 
 The figure below shows the high-level architecture:
 
-![http-to-hdfs.png](/images/http-to-hdfs.png)
+![HTTP-to-HDFS Overview](/images/http-to-hdfs.png)
 
 
 ## Install

--- a/guides/http-to-td.md
+++ b/guides/http-to-td.md
@@ -26,7 +26,7 @@ receive data from HTTP and stream it into TD.
 
 The figure below shows the high-level architecture:
 
-![treasuredata_architecture.png](/images/treasuredata_architecture.png)
+![TreasureData Architecture](/images/treasuredata_architecture.png)
 
 
 ## Install

--- a/guides/kinesis-stream.md
+++ b/guides/kinesis-stream.md
@@ -6,7 +6,7 @@ This article explains how to use [Fluentd](http://fluentd.org/)'s
 to aggregate semi-structured logs in real-time. Kinesis plugin is
 developed and published by Amazon Web Services officially.
 
-![fluentd-kinesis.png](/images/fluentd-kinesis.png)
+![Fluentd + Kinesis](/images/fluentd-kinesis.png)
 
 
 ## Background

--- a/guides/logs-to-sematext.md
+++ b/guides/logs-to-sematext.md
@@ -5,7 +5,7 @@ an alternative to Splunk, but with cheaper and more flexible [pricing](https://s
 In this article, we present an alternative to Splunk by combining Fluentd with
 the Sematext open Elasticsearch API.
 
-![sematext-dashboard.png](/images/sematext-dashboard.png)
+![Sematext Dashboard](/images/sematext-dashboard.png)
 
 
 [Elasticsearch](https://www.elastic.co/products/elasticsearch) is an open source
@@ -131,7 +131,7 @@ or with Kibana.
 First of all, open up the Seamtext UI and access your App. You'll see prebuilt
 dashboards with full-text search, filters, and alerts out-of-the-box.
 
-![sematext-configure-logs.png](/images/sematext-configure-logs.png)
+![Sematext: Configure Logs](/images/sematext-configure-logs.png)
 
 Sematext will automatically figure out hosts, idents, pids, timestamps,
 and the origin of the logs. In this case the origin is Fluentd.
@@ -142,7 +142,7 @@ and alerts to fine-tune your own personal use-case.
 If you are used to Kibana, you can still use it as well.
 For more details, read [Kibana's official manual](https://www.elastic.co/guide/en/kibana/current/index.html).
 
-![sematext-logs-overview.png](/images/sematext-logs-overview.png)
+![Sematext: Logs Overview](/images/sematext-logs-overview.png)
 
 
 ### Debugging

--- a/guides/raspberrypi-cloud-data-logger.md
+++ b/guides/raspberrypi-cloud-data-logger.md
@@ -6,7 +6,7 @@ single-board computer. Because it is low-cost and easy to equip with
 various types of sensors, using Raspberry Pi as a cloud data logger is
 one of its ideal use cases.
 
-![raspberry-pi-cloud-data-logger.png](/images/raspberry-pi-cloud-data-logger.png)
+![Cloud Data Logger by Raspberry Pi](/images/raspberry-pi-cloud-data-logger.png)
 
 This article introduces how to transport sensor data from Raspberry Pi
 to the cloud, using Fluentd as the data collector. For the cloud side,

--- a/guides/syslog-influxdb.md
+++ b/guides/syslog-influxdb.md
@@ -3,7 +3,7 @@
 This article shows how to collect `syslog` data into
 [InfluxDB](http://github.com/influxdb/influxdb) using Fluentd.
 
-![syslog-fluentd-influxdb.png](/images/syslog-fluentd-influxdb.png)
+![Syslog + Fluentd + InfluxDB](/images/syslog-fluentd-influxdb.png)
 
 
 ## Prerequisites
@@ -151,7 +151,7 @@ write SQL queries against your log data**.
 
 And then click `Visualization` and select line chart:
 
-![chronograf-explore-data.png](/images/chronograf-explore-data.png)
+![Chronograf: Explore Data](/images/chronograf-explore-data.png)
 
 Here, I am counting the number of lines of syslog messages per facility/priority:
 
@@ -161,11 +161,11 @@ SELECT COUNT(ident) FROM test.autogen./^system\./ GROUP BY time(1s)
 
 Click on "Submit Query" and you get a graph like this:
 
-![chronograf-query.png](/images/chronograf-query.png)
+![Chronograf: Query](/images/chronograf-query.png)
 
 Here is another screenshot just for the `system.daemon.info` series:
 
-![chronograf-query-2.png](/images/chronograf-query-2.png)
+![Chronograf: Query](/images/chronograf-query-2.png)
 
 
 ------------------------------------------------------------------------

--- a/install/install-by-msi.md
+++ b/install/install-by-msi.md
@@ -50,7 +50,7 @@ Open this Command Prompt from the Windows Start menu.
 
 Its icon looks like this on Windows Server 2012:
 
-![msi-td-agent-command-prompt.png](/images/msi-td-agent-command-prompt.png)
+![Td-agent Command Prompt](/images/msi-td-agent-command-prompt.png)
 
 Now, launch `td-agent` with the following command:
 
@@ -71,7 +71,7 @@ It is working properly if you see the following in the logs:
 test.event: {"k", "v"}
 ```
 
-[![td-agent-windows-prompt.png](/images/td-agent-windows-prompt.png)](/images/td-agent-windows-prompt.png)
+[![Td-agent Windows Prompt](/images/td-agent-windows-prompt.png)](/images/td-agent-windows-prompt.png)
 
 
 ### Step 3: Run `td-agent` as Windows service
@@ -148,7 +148,7 @@ After you have installed the .msi package, you will see the program called
 `Td-agent Command Prompt` installed. Please double click this icon in
 the Windows menu (below is how it looks like on Windows Server 2012).
 
-![msi-td-agent-command-prompt.png](/images/msi-td-agent-command-prompt.png)
+![Td-agent Command Prompt](/images/msi-td-agent-command-prompt.png)
 
 In the prompt, please execute the command below to launch `td-agent` process:
 
@@ -169,7 +169,7 @@ It's working properly if td-agent process outputs:
 test.event: {"k", "v"}
 ```
 
-[![td-agent-windows-prompt.png](/images/td-agent-windows-prompt.png)](/images/td-agent-windows-prompt.png)
+[![Td-agent Windows Prompt](/images/td-agent-windows-prompt.png)](/images/td-agent-windows-prompt.png)
 
 
 ### Step 3: Register `td-agent` to Windows Service

--- a/overview/logo.md
+++ b/overview/logo.md
@@ -5,7 +5,7 @@ Feel free to use these logos on your slides, blog posts, etc.
 
 ## Square
 
-[![Fluentd_square.png](/images/logo/Fluentd_square.png)](/images/logo/Fluentd_square.png)
+[![Fluentd Square Logo](/images/logo/Fluentd_square.png)](/images/logo/Fluentd_square.png)
 
 [\[PNG\]](/images/logo/Fluentd_square.png)
 [\[SVG\]](/images/logo/Fluentd_square.svg)
@@ -13,7 +13,7 @@ Feel free to use these logos on your slides, blog posts, etc.
 
 ## Horizontal
 
-[![Fluentd_horizontal.png](/images/logo/Fluentd_horizontal.png)](/images/logo/Fluentd_horizontal.png)
+[![Fluentd Horizontal Logo](/images/logo/Fluentd_horizontal.png)](/images/logo/Fluentd_horizontal.png)
 
 [\[PNG\]](/images/logo/Fluentd_horizontal.png)
 [\[SVG\]](/images/logo/Fluentd_horizontal.svg)
@@ -21,7 +21,7 @@ Feel free to use these logos on your slides, blog posts, etc.
 
 ## Icon
 
-[![Fluentd_icon.png](/images/logo/Fluentd_icon.png)](/images/logo/Fluentd_icon.png)
+[![Fluentd Icon](/images/logo/Fluentd_icon.png)](/images/logo/Fluentd_icon.png)
 
 [\[PNG\]](/images/logo/Fluentd_icon.png)
 [\[SVG\]](/images/logo/Fluentd_icon.svg)

--- a/overview/quickstart.md
+++ b/overview/quickstart.md
@@ -4,7 +4,7 @@ Let's get started with **Fluentd**! **Fluentd** is a fully free and
 fully open-source log collector that instantly enables you to have a
 '**Log Everything**' architecture with [125+ types of systems](https://www.fluentd.org/plugins).
 
-![fluentd-architecture.png](/images/fluentd-architecture.png)
+![Fluentd Architecture](/images/fluentd-architecture.png)
 
 Fluentd treats logs as JSON, a popular machine-readable format. It is
 written primarily in C with a thin-Ruby wrapper that gives users

--- a/plugins/buffer/README.md
+++ b/plugins/buffer/README.md
@@ -45,7 +45,7 @@ where chunks wait before the transportation. Every newly-created chunk
 starts from *stage*, then proceeds to *queue* in time (and subsequently
 gets transferred to the destination).
 
-[![fluentd-v0.14-plugin-api-overview.png](/images/fluentd-v0.14-plugin-api-overview.png)](/images/fluentd-v0.14-plugin-api-overview.png)
+[![Fluentd-v0.14 Plugin API Overview](/images/fluentd-v0.14-plugin-api-overview.png)](/images/fluentd-v0.14-plugin-api-overview.png)
 
 
 ## Control Retry Behavior

--- a/plugins/input/dummy.md
+++ b/plugins/input/dummy.md
@@ -1,6 +1,6 @@
 # `dummy` Input Plugin
 
-![dummy.png](/images/plugins/input/dummy.png)
+![](/images/plugins/input/dummy.png)
 
 The `in_dummy` input plugin generates dummy events. It is useful for
 testing, debugging, benchmarking and getting started with Fluentd.

--- a/plugins/input/exec.md
+++ b/plugins/input/exec.md
@@ -1,6 +1,6 @@
 # `exec` Input Plugin
 
-![exec.png](/images/plugins/input/exec.png)
+![](/images/plugins/input/exec.png)
 
 The `in_exec` Input plugin executes external programs to receive or pull
 event logs. It will then read TSV (tab separated values), JSON or

--- a/plugins/input/forward.md
+++ b/plugins/input/forward.md
@@ -1,6 +1,6 @@
 # `forward` Input Plugin
 
-![forward.png](/images/plugins/input/forward.png)
+![](/images/plugins/input/forward.png)
 
 The `in_forward` Input plugin listens to a TCP socket to receive the
 event stream. It also listens to a UDP socket to receive heartbeat

--- a/plugins/input/http.md
+++ b/plugins/input/http.md
@@ -1,6 +1,6 @@
 # HTTP Input Plugin
 
-![http.png](/images/plugins/input/http.png)
+![](/images/plugins/input/http.png)
 
 The `in_http` Input plugin allows you to send events through HTTP
 requests. Using this plugin, you can trivially launch a REST endpoint to

--- a/plugins/input/syslog.md
+++ b/plugins/input/syslog.md
@@ -1,6 +1,6 @@
 # `syslog` Input Plugin
 
-![syslog.png](/images/plugins/input/syslog.png)
+![](/images/plugins/input/syslog.png)
 
 The `in_syslog` Input plugin enables Fluentd to retrieve records via the
 syslog protocol on UDP or TCP.

--- a/plugins/input/tail.md
+++ b/plugins/input/tail.md
@@ -1,6 +1,6 @@
 # `tail` Input Plugin
 
-![tail.png](/images/plugins/input/tail.png)
+![](/images/plugins/input/tail.png)
 
 The `in_tail` Input plugin allows Fluentd to read events from the tail
 of text files. Its behavior is similar to the `tail -F` command.

--- a/plugins/input/tcp.md
+++ b/plugins/input/tcp.md
@@ -1,6 +1,6 @@
 # TCP Input Plugin
 
-![tcp.png](/images/plugins/input/tcp.png)
+![](/images/plugins/input/tcp.png)
 
 The `in_tcp` Input plugin enables Fluentd to accept TCP payload.
 

--- a/plugins/input/udp.md
+++ b/plugins/input/udp.md
@@ -1,6 +1,6 @@
 # UDP Input Plugin
 
-![udp.png](/images/plugins/input/udp.png)
+![](/images/plugins/input/udp.png)
 
 The `in_udp` Input plugin enables Fluentd to accept UDP payload.
 

--- a/plugins/output/copy.md
+++ b/plugins/output/copy.md
@@ -1,6 +1,6 @@
 # `copy` Output Plugin
 
-![copy.png](/images/plugins/output/copy.png)
+![](/images/plugins/output/copy.png)
 
 The `copy` output plugin copies events to multiple outputs.
 

--- a/plugins/output/elasticsearch.md
+++ b/plugins/output/elasticsearch.md
@@ -1,6 +1,6 @@
 # Elasticsearch Output Plugin
 
-![elasticsearch.png](/images/plugins/output/elasticsearch.png)
+![](/images/plugins/output/elasticsearch.png)
 
 The `out_elasticsearch` Output plugin writes records into Elasticsearch.
 By default, it creates records by bulk write operation. This means that

--- a/plugins/output/exec_filter.md
+++ b/plugins/output/exec_filter.md
@@ -1,6 +1,6 @@
 # `exec_filter` Output Plugin
 
-![exec_filter.png](/images/plugins/output/exec_filter.png)
+![](/images/plugins/output/exec_filter.png)
 
 The `out_exec_filter` Buffered Output plugin 1) executes an external program
 using an event as input; and, 2) reads a new event from the program output.

--- a/plugins/output/file.md
+++ b/plugins/output/file.md
@@ -1,6 +1,6 @@
 # `file` Output Plugin
 
-![file.png](/images/plugins/output/file.png)
+![](/images/plugins/output/file.png)
 
 The `out_file` Output plugin writes events to files. By default, it
 creates files on a daily basis (around 00:10). This means that when you

--- a/plugins/output/forward.md
+++ b/plugins/output/forward.md
@@ -1,6 +1,6 @@
 # `forward` Output Plugin
 
-![forward.png](/images/plugins/output/forward.png)
+![](/images/plugins/output/forward.png)
 
 The `out_forward` Buffered Output plugin forwards events to other
 fluentd nodes. This plugin supports load-balancing and automatic

--- a/plugins/output/kafka.md
+++ b/plugins/output/kafka.md
@@ -1,6 +1,6 @@
 # Apache Kafka Output Plugin
 
-![kafka.png](/images/plugins/output/kafka.png)
+![](/images/plugins/output/kafka.png)
 
 The `out_kafka2` Output plugin writes records into [Apache Kafka](https://kafka.apache.org/).
 

--- a/plugins/output/mongo.md
+++ b/plugins/output/mongo.md
@@ -1,6 +1,6 @@
 # MongoDB Output Plugin
 
-![mongo.png](/images/plugins/output/mongo.png)
+![](/images/plugins/output/mongo.png)
 
 The `out_mongo` Output plugin writes records into
 [MongoDB](http://mongodb.org/), the emerging document-oriented database system.

--- a/plugins/output/mongo_replset.md
+++ b/plugins/output/mongo_replset.md
@@ -1,6 +1,6 @@
 # MongoDB ReplicaSet Output Plugin
 
-![mongo_replset.png](/images/plugins/output/mongo_replset.png)
+![](/images/plugins/output/mongo_replset.png)
 
 The `out_mongo_replset` Output plugin writes records into
 [MongoDB](http://mongodb.org/), the emerging document-oriented database

--- a/plugins/output/null.md
+++ b/plugins/output/null.md
@@ -1,6 +1,6 @@
 # `null` Output Plugin
 
-![null.png](/images/plugins/output/null.png)
+![](/images/plugins/output/null.png)
 
 The `null` output plugin just throws away events.
 

--- a/plugins/output/s3.md
+++ b/plugins/output/s3.md
@@ -1,6 +1,6 @@
 # Amazon S3 Output Plugin
 
-![s3.png](/images/plugins/output/s3.png)
+![](/images/plugins/output/s3.png)
 
 The `out_s3` Output plugin writes records into the Amazon S3 cloud
 object storage service. By default, it creates files on an hourly basis.

--- a/plugins/output/secondary_file.md
+++ b/plugins/output/secondary_file.md
@@ -1,6 +1,6 @@
 # `secondary_file` Output Plugin
 
-![file.png](/images/plugins/output/file.png)
+![](/images/plugins/output/file.png)
 
 The `out_secondary_file` Output plugin writes chunks to files. This plugin is
 similar to `out_file` but this is for `<secondary>` use-case.

--- a/plugins/output/stdout.md
+++ b/plugins/output/stdout.md
@@ -1,6 +1,6 @@
 # `stdout` Output Plugin
 
-![stdout.png](/images/plugins/output/stdout.png)
+![](/images/plugins/output/stdout.png)
 
 The `stdout` output plugin prints events to the standard output (or logs if
 launched as a daemon). This output plugin is useful for debugging purposes.

--- a/plugins/output/webhdfs.md
+++ b/plugins/output/webhdfs.md
@@ -1,6 +1,6 @@
 # HDFS (WebHDFS) Output Plugin
 
-![webhdfs.png](/images/plugins/output/webhdfs.png)
+![](/images/plugins/output/webhdfs.png)
 
 The `out_webhdfs` Output plugin writes records into HDFS (Hadoop
 Distributed File System). By default, it creates files on an hourly


### PR DESCRIPTION
Updated description of images (screenshots and demos) from image filenames to adequate captions.
Removed description of images from plugin articles from right under their respective headings as they seem redundant.

Example: `tail.png` under the image of [tail input plugin](https://docs.fluentd.org/input/tail)


Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>