### PR TITLE
Fix Elasticsearch setup doc typo

### DIFF
--- a/guides/free-alternative-to-splunk-by-fluentd.md
+++ b/guides/free-alternative-to-splunk-by-fluentd.md
@@ -174,7 +174,7 @@ to Elasticsearch, you can view, search and visualize the log data using
 Kibana.
 
 For starters, let's access `http://localhost:5601` and click the `Set
-up index patters` button in the upper-right corner of the screen.
+up index patterns` button in the upper-right corner of the screen.
 
 ![Kibana Top Menu](/images/kibana6-screenshot-topmenu.png)
 


### PR DESCRIPTION
Fixing minor typo in the Elasticsearch documentation page.