### PR TITLE
filter_parser: Fix a broken table

### DIFF
--- a/plugins/filter/parser.md
+++ b/plugins/filter/parser.md
@@ -149,7 +149,8 @@ With above configuration, here is the result:
 ### `replace_invalid_sequence`
 
 | type | default | version |
-|:-----|:--------|:--------||bool | false   | 0.14.9  |
+|:-----|:--------|:--------|
+| bool | false   | 0.14.9  |
 
 If `true`, invalid string is replaced with safe characters and re-parse it.
 


### PR DESCRIPTION
`replace_invalid_sequence` description table is broken.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>