### PR TITLE
rewrite_tag_filter: Fix the incorrect pattern

### DIFF
--- a/plugins/output/rewrite_tag_filter.md
+++ b/plugins/output/rewrite_tag_filter.md
@@ -26,7 +26,7 @@ prefixed with the value of the key `message`:
   @type rewrite_tag_filter
   <rule>
     key message
-    pattern /^(w+)$/
+    pattern /^\[(\w+)\]/
     tag $1.${tag}
   </rule>
 </match>


### PR DESCRIPTION
The pattern should be `/^\[(\w+)\]/`. From the record `{"message":"[info]: ..."} `, the line starts with `[`, instead of the word `info`.

FYI: https://github.com/fluent/fluent-plugin-rewrite-tag-filter/issues/103