### PR TITLE
Fix ElasticSearch → Elasticsearch

### DIFF
--- a/filter/geoip.md
+++ b/filter/geoip.md
@@ -126,7 +126,7 @@ This parameter has been deprecated since v1.2.0.
 
 Set to `true` to skip adding the field with `[null, null]` array.
 
-This is useful for ElasticSearch.
+This is useful for Elasticsearch.
 
 ### `backend_library`
 

--- a/how-to-guides/free-alternative-to-splunk-by-fluentd.md
+++ b/how-to-guides/free-alternative-to-splunk-by-fluentd.md
@@ -41,7 +41,7 @@ Once the installation is complete, start Elasticsearch:
 $ ./bin/elasticsearch
 ```
 
-Note: You can also install ElasticSearch \(and Kibana\) using RPM/DEB packages. For details, please refer to [the official instructions](https://www.elastic.co/downloads).
+Note: You can also install Elasticsearch \(and Kibana\) using RPM/DEB packages. For details, please refer to [the official instructions](https://www.elastic.co/downloads).
 
 ## Set Up Kibana
 


### PR DESCRIPTION
Minor typo fix, from ElasticSearch to Elasticsearch.