### PR TITLE
Add new system config `disable_shared_socket` as of Fluentd 1.12.1

### DIFF
--- a/deployment/command-line-option.md
+++ b/deployment/command-line-option.md
@@ -11,7 +11,7 @@ Usage: fluentd [options]
     -s, --setup [DIR=/etc/fluent]    install sample configuration file to the directory
     -c, --config PATH                config file path (default: /etc/fluent/fluent.conf)
         --dry-run                    Check fluentd setup is correct or not
-        --show-plugin-config=PLUGIN  Show PLUGIN configuration and exit(ex: input:dummy)
+        --show-plugin-config=PLUGIN  [DEPRECATED] Show PLUGIN configuration and exit(ex: input:dummy)
     -p, --plugin DIR                 add plugin directory
     -I PATH                          add library path
     -r NAME                          load library
@@ -34,11 +34,14 @@ Usage: fluentd [options]
         --without-source             invoke a fluentd without input plugins
         --use-v1-config              Use v1 configuration format (default)
         --use-v0-config              Use v0 configuration format
+        --strict-config-value        Parse config values strictly
     -v, --verbose                    increase verbose level (-v: debug, -vv: trace)
     -q, --quiet                      decrease verbose level (-q: warn, -qq: error)
         --suppress-config-dump       suppress config dumping when fluentd starts
     -g, --gemfile GEMFILE            Gemfile path
     -G, --gem-path GEM_INSTALL_PATH  Gemfile install path (default: $(dirname $gemfile)/vendor/bundle)
+        --conf-encoding ENCODING     specify configuration file encoding
+        --disable-shared-socket      Don't open shared socket for multiple workers
 ```
 
 ### Important Options

--- a/deployment/system-config.md
+++ b/deployment/system-config.md
@@ -148,6 +148,14 @@ Specifies the directory permission in the octal format.
 
 Parses config values strictly. Invalid numerical or boolean values are not allowed. Fluentd raises configuration error instead of replacing them with `0` or `true` implicitly.
 
+### `disable_shared_socket`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| bool | nil | 1.12.1 |
+
+Force disable the shared socket which is for listening a same port across multiple worker processes. When the shared socket is enabled (it's the default behavior), a socket is always created to enable workers to communicate with the supervisor. On Windows, it consumes a dynamic (a.k.a ephemeral) TCP port. If you don't prefer it, set this option as `true`. When it's disabled, you may not use plugins that listen a port such as in_forward, in_http and in_syslog.
+
 ### `<log>` section
 
 #### `format`


### PR DESCRIPTION
In addition, add some missing command line options.
