### PR TITLE
Update regex in apache2 parser plugin

### DIFF
--- a/parser/apache2.md
+++ b/parser/apache2.md
@@ -11,7 +11,7 @@ See [Parse Section Configurations](../configuration/parse-section.md)
 Here is the regexp and time format patterns of this plugin:
 
 ```text
-expression /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/
+expression /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>(?:[^\"]|\\.)*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>(?:[^\"]|\\.)*)" "(?<agent>(?:[^\"]|\\.)*)")?$/
 time_format %d/%b/%Y:%H:%M:%S %z
 ```
 


### PR DESCRIPTION
Since https://github.com/fluent/fluentd/commit/df5ac352f916c1118fba0ddd61cf6cea2b4a1b70 , the regex has been updated. The one provided in docs will actually fail to match certain Apache logs.