### PR TITLE
1.0: link to overview of parser instead of missing document

### DIFF
--- a/plugin-development/api-plugin-parser.md
+++ b/plugin-development/api-plugin-parser.md
@@ -1,6 +1,6 @@
 # How to Write Parser Plugin
 
-Fluentd supports [pluggable and customizable formats for input plugins](https://github.com/fluent/fluentd-docs-gitbook/tree/da81ba70252eaa863cc28fc888584c59d6fc14d3/developer/parser-plugin-overview/README.md). The plugin filenames prefixed `parser_` are registered as Parser Plugins.
+Fluentd supports [pluggable and customizable formats for input plugins](/parser/README.md). The plugin filenames prefixed `parser_` are registered as Parser Plugins.
 
 See [Plugin Base Class API](api-plugin-base.md) for details on the common APIs for all the plugin types.
 


### PR DESCRIPTION
Closes: #257
