### PR TITLE
Update "OS X" to "macOS" and correct minor typos

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,7 +12,7 @@
   * [Before Installation](installation/before-install.md)
   * [Install by RPM Package \(Red Hat Linux\)](installation/install-by-rpm.md)
   * [Install by DEB Package \(Debian/Ubuntu\)](installation/install-by-deb.md)
-  * [Install by .dmg Package \(MacOS X\)](installation/install-by-dmg.md)
+  * [Install by .dmg Package \(macOS\)](installation/install-by-dmg.md)
   * [Install by .msi Installer \(Windows\)](installation/install-by-msi.md)
   * [Install by Ruby Gem](installation/install-by-gem.md)
   * [Install from Source](installation/install-from-source.md)
@@ -177,4 +177,3 @@
   * [Plugin Helper: Http Server](plugin-helper-overview/api-plugin-helper-http_server.md)
   * [Plugin Helper: Service Discovery](plugin-helper-overview/api-plugin-helper-service_discovery.md)
 * [Troubleshooting Guide](troubleshooting-guide.md)
-

--- a/deployment/linux-capability.md
+++ b/deployment/linux-capability.md
@@ -5,7 +5,7 @@ This article shows configuration and dependent gem installation instruction for 
 ## Prerequisites
 
 * gcc and make etc. for building C extension sources
-* libcap-ng package and its depelopment package
+* libcap-ng package and its development package
   * libcap-ng-dev on Debian GNU/Linux and Ubuntu
   * libcap-ng-devel on CentOS 7/8, Fedora 33, AmazonLinux 2
 * pkg-config package for linking libcap-ng library
@@ -178,4 +178,3 @@ $ bundle exec fluentd -c in_tail_camouflage_permission.conf
 Fluentd which is running on ordinal user does not complain as `Permission denied`. Users can retrieve root files' contents on non-root process, yay!
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-

--- a/filter/geoip.md
+++ b/filter/geoip.md
@@ -17,7 +17,7 @@ $ sudo yum install geoip-devel --enablerepo=epel
 $ sudo apt install build-essential
 $ sudo apt install libgeoip-dev
 
-# for MacOSX (brew)
+# for macOS (brew)
 $ brew install geoip
 ```
 

--- a/how-to-guides/free-alternative-to-splunk-by-fluentd.md
+++ b/how-to-guides/free-alternative-to-splunk-by-fluentd.md
@@ -45,7 +45,7 @@ Note: You can also install Elasticsearch \(and Kibana\) using RPM/DEB packages. 
 
 ## Set Up Kibana
 
-To install Kibana, download it from the official website and extract it. Kibana is an HTML/CSS/JavaScript application \([download](https://www.elastic.co/downloads/kibana)\). Use the binary for 64-bit Linux systems. For this article, we download the binary for MacOS X.
+To install Kibana, download it from the official website and extract it. Kibana is an HTML/CSS/JavaScript application \([download](https://www.elastic.co/downloads/kibana)\). Use the binary for 64-bit Linux systems. For this article, we download the binary for macOS.
 
 ```text
 $ curl -O https://artifacts.elastic.co/downloads/kibana/kibana-6.1.0-linux-x86_64.tar.gz

--- a/how-to-guides/syslog-influxdb.md
+++ b/how-to-guides/syslog-influxdb.md
@@ -9,11 +9,11 @@ This article shows how to collect `syslog` data into [InfluxDB](http://github.co
 * A basic understanding of Fluentd
 * A running instance of `rsyslogd`
 
-**In this guide, we assume we are running `td-agent` \(Fluentd package for Linux and OSX\) on Ubuntu Xenial.**
+**In this guide, we assume we are running `td-agent` \(Fluentd package for Linux and macOS\) on Ubuntu Xenial.**
 
 ## Step 1: Install InfluxDB
 
-InfluxDB supports Ubuntu, RedHat and OSX \(via `brew`\).
+InfluxDB supports Ubuntu, RedHat and macOS \(via `brew`\).
 
 For more details, see [here](http://influxdb.com/download/).
 

--- a/input/tail.md
+++ b/input/tail.md
@@ -32,7 +32,7 @@ If `td-agent` restarts, it resumes reading from the last position before the res
 
 ### Linux Capability
 
-Since v1.12.0, `in_tail` handles the following Linux cababilities if Fluentd's Linux capability handling module is enabled:
+Since v1.12.0, `in_tail` handles the following Linux capabilities if Fluentd's Linux capability handling module is enabled:
 
 * `CAP_DAC_READ_SEARCH` \(`:dac_read_search` on `in_tail` code.\)
 * `CAP_DAC_OVERRIDE` \(`:dac_override` on `in_tail` code.\)
@@ -331,7 +331,7 @@ The `rotate_wait` parameter accepts a single integer representing the number of 
 
 Enables the additional watch timer. Setting this parameter to `false` will significantly reduce CPU and I/O consumption when tailing a large number of files on systems with `inotify` support. The default is `true` which results in an additional 1 second timer being used.
 
-`in_tail` \(via `Cool.io`\) uses `inotify` on systems which support it. Earlier versions of `libev` on some platforms \(e.g. MacOS X\) did not work properly; therefore, an explicit 1 second timer was used. Even on systems with `inotify` support, this results in additional I/O each second, for every file being tailed.
+`in_tail` \(via `Cool.io`\) uses `inotify` on systems which support it. Earlier versions of `libev` on some platforms \(e.g. macOS\) did not work properly; therefore, an explicit 1 second timer was used. Even on systems with `inotify` support, this results in additional I/O each second, for every file being tailed.
 
 Early testing demonstrates that modern `Cool.io` and `in_tail` work properly without the additional watch timer. In the future, depending on the feedback and testing, the additional watch timer may be disabled by default.
 

--- a/installation/install-by-dmg.md
+++ b/installation/install-by-dmg.md
@@ -1,6 +1,6 @@
-# Install by .dmg Package \(MacOS X\)
+# Install by .dmg Package \(macOS\)
 
-This article explains how to install `td-agent`, the stable Fluentd distribution package maintained by [Treasure Data, Inc](https://www.treasuredata.com/), on MacOS X.
+This article explains how to install `td-agent`, the stable Fluentd distribution package maintained by [Treasure Data, Inc](https://www.treasuredata.com/), on macOS.
 
 ## What is `td-agent`?
 
@@ -8,7 +8,7 @@ Fluentd is written in Ruby for flexibility, with performance-sensitive parts in 
 
 That is why [Treasure Data, Inc](http://www.treasuredata.com/) provides **the stable distribution of Fluentd**, called `td-agent`. The differences between Fluentd and `td-agent` can be found [here](https://www.fluentd.org/faqs).
 
-For MacOS X, `td-agent` is distributed as `.dmg` installer.
+For macOS, `td-agent` is distributed as `.dmg` installer.
 
 ## Step 1: Install `td-agent`
 
@@ -51,9 +51,9 @@ $ tail -n 1 /var/log/td-agent/td-agent.log
 
 ## Uninstall td-agent
 
-On MacOS, `td-agent` does not provide any uninstallation app like `rpm` / `deb` on Ubuntu.
+On macOS, `td-agent` does not provide any uninstallation app like `rpm` / `deb` on Ubuntu.
 
-To uninstall `td-agent` from MacOS, remove these files / directories:
+To uninstall `td-agent` from macOS, remove these files / directories:
 
 * `/Library/LaunchDaemons/td-agent.plist`
 * `/etc/td-agent`

--- a/output/s3.md
+++ b/output/s3.md
@@ -40,7 +40,7 @@ Please see the [Store Apache Logs into Amazon S3](../how-to-guides/apache-to-s3.
 
 Please see the [Config File](../configuration/config-file.md) article for the basic structure and syntax of the configuration file.
 
-For `<buffer>` section, see [Buffer Section Cofiguration](../configuration/buffer-section.md). By default, this plugin uses the [`file`](../buffer/file.md) buffer.
+For `<buffer>` section, see [Buffer Section Configuration](../configuration/buffer-section.md). By default, this plugin uses the [`file`](../buffer/file.md) buffer.
 
 ## Parameters
 

--- a/plugin-development/api-config-types.md
+++ b/plugin-development/api-config-types.md
@@ -72,7 +72,7 @@ Configuration Example:
 
 ```text
 name John Titor
-passowrd very-secret-password
+password very-secret-password
 ```
 
 ### `:regexp`
@@ -345,4 +345,3 @@ This configurations will be converted to:
 ```
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-

--- a/plugin-helper-overview/api-plugin-helper-inject.md
+++ b/plugin-helper-overview/api-plugin-helper-inject.md
@@ -30,7 +30,7 @@ For more details, see [Inject section](../configuration/inject-section.md).
 
 ## Methods
 
-### `inject_values_to_recort(tag, time, record)`
+### `inject_values_to_record(tag, time, record)`
 
 This method injects values to the given record and returns the new record.
 
@@ -73,4 +73,3 @@ end
 * [`out_stdout`](../output/stdout.md)
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-

--- a/plugin-helper-overview/api-plugin-helper-socket.md
+++ b/plugin-helper-overview/api-plugin-helper-socket.md
@@ -95,7 +95,7 @@ If the block is given, it will be invoked with the socket instance as a paramete
 
 #### `send_keepalive_packet` Use Case
 
-If you set `true` to `send_keepavlie_packet`, you also need to configure keep-alive related kernel parameters:
+If you set `true` to `send_keepalive_packet`, you also need to configure keep-alive related kernel parameters:
 
 ```ruby
 net.ipv4.tcp_keepalive_intvl = 75
@@ -153,4 +153,3 @@ If block is given, it will be invoked with the socket instance as a parameter, a
 * [`out_forward`](../output/forward.md)
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-

--- a/plugins/input/dummy.md
+++ b/plugins/input/dummy.md
@@ -1,6 +1,6 @@
 # `dummy` Input Plugin
 
-`in_dummy` has been renamed `in_sample` since Fluetd v1.11.12.
+`in_dummy` has been renamed `in_sample` since Fluentd v1.11.12.
 See [`sample` input plugin](/plugins/input/sample.md) article for more details.
 
 You can keep to use following configuration in v1:

--- a/quickstart/faq.md
+++ b/quickstart/faq.md
@@ -56,7 +56,7 @@ If you get other errors, google it.
 
 ### fluentd raises `tzinfo` conflict error after installed plugins
 
-Fluentd supports tzinfo v1.1 or later and recent td-agent / official images install tzinfo v2 by default. The problem is several plugins depend on ActiveSupport and ActiveSuppot doesn't support tzinfo v2. To resolve this problem, there are 2 approaches.
+Fluentd supports tzinfo v1.1 or later and recent td-agent / official images install tzinfo v2 by default. The problem is several plugins depend on ActiveSupport and ActiveSupport doesn't support tzinfo v2. To resolve this problem, there are 2 approaches.
 
 * Uninstall tzinfo v2 and install tzinfo v1.1 manually
 * Update plugin to remove ActiveSupport dependency. ActiveSupport is mainly for Ruby on Rails,
@@ -116,4 +116,3 @@ If you are willing to write Regexp, [fluentd-ui's `in_tail` editor](../deploymen
 If you do NOT want to write any Regexp, look at [the Grok parser](https://github.com/kiyoto/fluent-plugin-grok-parser).
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-

--- a/quickstart/td-agent-v2-vs-v3-vs-v4.md
+++ b/quickstart/td-agent-v2-vs-v3-vs-v4.md
@@ -19,7 +19,7 @@
 | Debian Jessie | ✔ | ✔ |  |  |
 | Debian Stretch | ✔ | ✔ |  |  |
 | Debian Buster |  | ✔ | ✔ | ✔ |
-| MacOSX | ✔ | ✔ |  |  |
+| macOS | ✔ | ✔ |  |  |
 | Windows |  | ✔ | ✔ |  |
 
 ## Features
@@ -52,7 +52,7 @@ This is for v0.12 and old distribution users. We don't recommend this version fo
 * [Ubuntu/Debian](../installation/install-by-deb.md)
 * [RedHat/CentOS](../installation/install-by-rpm.md)
 * [Windows](../installation/install-by-msi.md)
-* [MacOS](../installation/install-by-dmg.md)
+* [macOS](../installation/install-by-dmg.md)
 * [RubyGems](../installation/install-by-gem.md)
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.

--- a/service_discovery/srv.md
+++ b/service_discovery/srv.md
@@ -4,7 +4,7 @@ The `srv` service discovery plugin updates the targets by [SRV Record](https://t
 
 ## Example Configuration
 
-Here is an example of `out_forward` updating the targets to get the SRV record from `_fluentd._tcp.exmaple.com`:
+Here is an example of `out_forward` updating the targets to get the SRV record from `_fluentd._tcp.example.com`:
 
 ```text
 <match pattern>


### PR DESCRIPTION
Apple's operating system used to be called "Mac OS X" or "OS X" for short, but since 2016 is known as "macOS." This PR includes that update, as well as a few minor typo fixes.