### PR TITLE
Document new plugin features in v1.12.2

### DIFF
--- a/formatter/ltsv.md
+++ b/formatter/ltsv.md
@@ -43,6 +43,14 @@ Adds `\n` to the result.
 
 Specify newline characters.
 
+### `replacement`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | ` ` \(SPACE\) | 1.12.2 |
+
+Safe replacement to substitute delimiters characters in records.
+
 ## Example
 
 ```text

--- a/output/copy.md
+++ b/output/copy.md
@@ -149,5 +149,25 @@ If plugin1's emit/format raises an error, plugin2 is not executed. If you want t
 </match>
 ```
 
+### `ignore_if_prev_successes` argument
+
+Since Fluentd v1.12.2, you can use `ignore_if_prev_successes` to define fallback outputs.  For example:
+
+```
+<match app.**>
+  @type copy
+  <store ignore_error>
+    @type plugin1
+    name c0
+  </store>
+  <store ignore_if_prev_success ignore_error>
+    @type plugin2
+    name c1
+  </store>
+</match>
+```
+
+Fluentd will make use of plugin2 only if the preceeding destinations (plugin1 in this case) fail.
+
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
 


### PR DESCRIPTION
I added descriptions for the features that we added in v1.12.2,
but have not yet documented.

With this merged, docs.fluentd.org should be keep in line with
the latest release. For details, see:

https://www.fluentd.org/blog/fluentd-v1.12.2-has-been-released

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>