### PR TITLE
Revert "Add replacement config for formatter_ltsv"

### DIFF
--- a/parser/ltsv.md
+++ b/parser/ltsv.md
@@ -32,14 +32,6 @@ The delimiter pattern of TSV values. This parameter overwrites `delimiter` param
 
 The delimiter character between field name and value.
 
-### `replacement`
-
-| type | default | version |
-| :--- | :--- | :--- |
-| string | ` ` | 1.12.2 |
-
-The replacement character for delimiter characters in value to prevent creating malformed LTSV.
-
 ## Example for LTSV
 
 This incoming event:


### PR DESCRIPTION
This reverts commit #292 (1368ae294d6a076e2b8fc9efa93bfd2cf5e8b70c).

Because it's wrogly added to the parser_ltsv page.
The formatter_ltsv page has been updated at #295 (21a85bbf7e32ccfab42e624b289edd5bbf4f685d).
