### PR TITLE
1.0: Update outdated PHP version

### DIFF
--- a/language-bindings/php.md
+++ b/language-bindings/php.md
@@ -8,7 +8,7 @@ This article explains how to use it.
 
 * Basic knowledge of PHP
 * Basic knowledge of Fluentd
-* PHP 5.3 or higher
+* PHP 5.6 or higher
 
 ## Installing Fluentd
 


### PR DESCRIPTION
It should be PHP 5.6 or later.

ref. https://github.com/fluent/fluent-logger-php/blob/master/composer.json

Closes: #293

Signed-off-by: Kentaro Hayashi <kenhys@gmail.com>