### PR TITLE
Fix a broken link to td-agent website

### DIFF
--- a/deployment/fluentd-ui.md
+++ b/deployment/fluentd-ui.md
@@ -1,6 +1,6 @@
 # Fluentd UI
 
-[fluentd-ui](https://github.com/fluent/fluentd-ui) is a browser-based [fluentd](http://fluentd.org/) and [td-agent](http://docs.treasuredata.com/articles/td-agent) manager that supports the following operations:
+[fluentd-ui](https://github.com/fluent/fluentd-ui) is a browser-based [fluentd](http://fluentd.org/) and [td-agent](https://docs.treasuredata.com/display/public/PD/About+Treasure+Data%27s+Server-Side+Agent) manager that supports the following operations:
 
 * Install, uninstall, and upgrade Fluentd plugins
 * Start/stop/restart fluentd process


### PR DESCRIPTION
Although same links are still remained in installation/install-by-rpm.md
and installation/install-by-deb.md, they shouldn't be fixed yet because
they are example of systemd's output. We'll fix the system unit file
before replacing them:

https://github.com/fluent-plugins-nursery/td-agent-builder/pull/298

Signed-off-by: Takuro Ashie <ashie@clear-code.com>