### PR TITLE
Fix a wrong destination address in graylog example

### DIFF
--- a/how-to-guides/graylog2.md
+++ b/how-to-guides/graylog2.md
@@ -110,7 +110,7 @@ Configure `/etc/td-agent/td-agent.conf` as follows:
 
 <match graylog2.**>
   @type gelf
-  host 0.0.0.0
+  host 127.0.0.1
   port 12201
   <buffer>
     flush_interval 5s


### PR DESCRIPTION
`0.0.0.0` is invalid as a destination address.

The original patch is posted by Alex Heylin <alexh@gmal.co.uk> in
https://github.com/fluent/fluentd-docs-gitbook/pull/141
Thanks!

Signed-off-by: Takuro Ashie <ashie@clear-code.com>