### PR TITLE
1.0: Mitigate descriptions for hardlink/symlink attack

### DIFF
--- a/installation/before-install.md
+++ b/installation/before-install.md
@@ -57,6 +57,8 @@ These kernel options were originally taken from the presentation [How Netflix Tu
 
 ## Use sticky bit symlink/hardlink protection
 
+**NOTE:** CentOS 7 or later, Ubuntu 18.04 (bionic) or later, and Debian GNU/Linux 10 (buster) or later are supported these parameters.
+
 Fluentd sometimes uses predictable paths for dumping, writing files, and so on.
 For symlink attack protection, check the following parameters are set up as `1`:
 
@@ -67,7 +69,6 @@ fs.protected_symlinks = 1
 
 This settings are almost enough for time-of-check to time-of-use (TOCTOU, TOCTTOU or TOC/TOU) which is a class of software bugs.
 
-CentOS 7 or later, Ubuntu 18.04 (bionic) or later, and Debian GNU/Linux 10 (buster) or later are supported these parameters.
 If you turned off these protection, please turn on them.
 
 Use `sysctl -p` command or reboot your node for the changes to take effect.

--- a/installation/before-install.md
+++ b/installation/before-install.md
@@ -60,6 +60,8 @@ These kernel options were originally taken from the presentation [How Netflix Tu
 **NOTE:** CentOS 7 or later, Ubuntu 18.04 (bionic) or later, and Debian GNU/Linux 10 (buster) or later are supported these parameters.
 
 Fluentd sometimes uses predictable paths for dumping, writing files, and so on.
+This default settings for the protections are in `/etc/sysctl.d/10-link-restrictions.conf`, or `/usr/lib/sysctl.d/50-default.conf` or elsewhere.
+
 For symlink attack protection, check the following parameters are set up as `1`:
 
 ```text

--- a/installation/before-install.md
+++ b/installation/before-install.md
@@ -68,7 +68,7 @@ fs.protected_symlinks = 1
 This settings are almost enough for time-of-check to time-of-use (TOCTOU, TOCTTOU or TOC/TOU) which is a class of software bugs.
 
 CentOS 7 or later, Ubuntu 18.04 (bionic) or later, and Debian GNU/Linux 10 (buster) or later are supported these parameters.
-If you truned off these protection, please turn on them.
+If you turned off these protection, please turn on them.
 
 Use `sysctl -p` command or reboot your node for the changes to take effect.
 

--- a/installation/before-install.md
+++ b/installation/before-install.md
@@ -67,6 +67,9 @@ fs.protected_symlinks = 1
 
 This settings are almost enough for time-of-check to time-of-use (TOCTOU, TOCTTOU or TOC/TOU) which is a class of software bugs.
 
+CentOS 7 or later, Ubuntu 18.04 (bionic) or later, and Debian GNU/Linux 10 (buster) or later are supported these parameters.
+If you truned off these protection, please turn on them.
+
 Use `sysctl -p` command or reboot your node for the changes to take effect.
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.

--- a/installation/before-install.md
+++ b/installation/before-install.md
@@ -55,5 +55,18 @@ Use `sysctl -p` command or reboot your node for the changes to take effect.
 
 These kernel options were originally taken from the presentation [How Netflix Tunes EC2 Instances for Performance](https://www.slideshare.net/brendangregg/how-netflix-tunes-ec2-instances-for-performance) by [Brendan Gregg](http://www.brendangregg.com/), Senior Performance Architect at AWS re:Invent 2017.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
+## Use sticky bit symlink/hardlink protection
 
+Fluentd sometimes uses predictable paths for dumping, writing files, and so on.
+For symlink attack protection, check the following parameters are set up as `1`:
+
+```text
+fs.protected_hardlinks = 1
+fs.protected_symlinks = 1
+```
+
+This settings are almost enough for time-of-check to time-of-use (TOCTOU, TOCTTOU or TOC/TOU) which is a class of software bugs.
+
+Use `sysctl -p` command or reboot your node for the changes to take effect.
+
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.


### PR DESCRIPTION
This is usual software vulnerabilities for hardlink/symlink.
Fluentd sometimes uses symlink and predictable paths.
Predictable paths always are used in sigdump.
Which is known vulnerability of Fluentd agent.

Specifying `fs.protected_hardlinks` and `fs.protected_symlinks` to be set
up as `1` is popular approach to mitigate this vulnerability.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>