### PR TITLE
Fix: Change hostname to host

### DIFF
--- a/monitoring-fluentd/monitoring-prometheus.md
+++ b/monitoring-fluentd/monitoring-prometheus.md
@@ -70,7 +70,7 @@ Configure the `copy` plugin with `prometheus` output plugin to count the outgoin
     @type forward
     <server>
       name myserver1
-      hostname 192.168.1.3
+      host 192.168.1.3
       port 24224
       weight 60
     </server>


### PR DESCRIPTION
Without the fix, Fluentd does not start and logs an error
...
`error_class=Fluent::ConfigError error="'host' parameter is required, in section server"`
...
The change adjusts to what is in the current master in the linked example
https://github.com/kzk/fluentd-prometheus-config-example/blob/c03d7797606c63830ebd6715d223ede282f19e34/fluentd.conf#L28