### PR TITLE
1.0: use {% include %} directive for footer content

### DIFF
--- a/.gitbook/assets/footer.txt
+++ b/.gitbook/assets/footer.txt
@@ -1,0 +1,3 @@
+---
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
+

--- a/buffer/README.md
+++ b/buffer/README.md
@@ -159,5 +159,4 @@ This sometimes causes a problem when the output destination has a payload size l
 * [`buf_memory`](memory.md)
 * [`buf_file`](file.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/buffer/file.md
+++ b/buffer/file.md
@@ -96,5 +96,4 @@ If you use this plugin under the multi-process environment, you need to use `@id
 
 Caution: `file` buffer implementation depends on the characteristics of the local file system. Don't use `file` buffer on remote file systems e.g. NFS, GlusterFS, HDFS, etc. We observed major data loss by using the remote file system.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/buffer/file_single.md
+++ b/buffer/file_single.md
@@ -100,5 +100,4 @@ This limitation will be removed by adding the metadata header in the file.
 
 Caution: `file_single` buffer implementation depends on the characteristics of the local file system. Don't use `file_single` buffer on remote file systems e.g. NFS, GlusterFS, HDFS and etc. We observed major data loss by using remote file system.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/buffer/memory.md
+++ b/buffer/memory.md
@@ -19,5 +19,4 @@ The `memory` buffer plugin provides a fast buffer implementation. It uses memory
 </match>
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/configuration/buffer-section.md
+++ b/configuration/buffer-section.md
@@ -548,5 +548,4 @@ With `exponential_backoff`, `retry_wait` interval will be calculated as below:
 * k: number of retry times
 * total retry time: `c + c * b^1 + (...) + c*b^k = c*b^(k+1) - 1`
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/configuration/config-file.md
+++ b/configuration/config-file.md
@@ -605,5 +605,4 @@ The forward slash `\` is interpreted as an escape character. You need `\` for se
 str_param   "foo\nbar" # \n is interpreted as actual LF character
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/configuration/extract-section.md
+++ b/configuration/extract-section.md
@@ -96,5 +96,4 @@ The **extract** section can be under `<match>`, `<source>`, or `<filter>` sectio
     4. Region/Zone \(e.g. `Asia/Tokyo`\)
     5. Region/Zone/Zone \(e.g. `America/Argentina/Buenos_Aires`\)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/configuration/format-section.md
+++ b/configuration/format-section.md
@@ -115,5 +115,4 @@ The `@type` parameter specifies the type of the formatter plugin.
     4. Region/Zone \(e.g. `Asia/Tokyo`\)
     5. Region/Zone/Zone \(e.g. `America/Argentina/Buenos_Aires`\)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/configuration/inject-section.md
+++ b/configuration/inject-section.md
@@ -134,5 +134,4 @@ Injected Record:
     4. Region/Zone \(e.g. `Asia/Tokyo`\)
     5. Region/Zone/Zone \(e.g. `America/Argentina/Buenos_Aires`\)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/configuration/parse-section.md
+++ b/configuration/parse-section.md
@@ -215,5 +215,4 @@ For the `types` parameter, the following types are supported:
 
   In the above use case, the timestamp is parsed as `unixtime` at first, if it fails, then it is parsed as `%iso8601` secondary. Note that `time_format_fallbacks` is the last resort to parse mixed timestamp format. There is a performance penalty \(Typically, N fallbacks are specified in `time_format_fallbacks` and if the last specified format is used as a fallback, N times slower in the worst case\).
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/configuration/plugin-common-parameters.md
+++ b/configuration/plugin-common-parameters.md
@@ -95,5 +95,4 @@ NOTE: The values for the `@label` parameter MUST start with `@` character.
 
 Specifying `@label` is strongly recommended to route events to any plugin without modifying the tags. It helps make the complex configuration modular and simple.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/configuration/routing-examples.md
+++ b/configuration/routing-examples.md
@@ -184,5 +184,4 @@ Use [out\_relabel](../output/relabel.md) plugin. This plugin simply emits events
 </label>
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/configuration/service_discovery-section.md
+++ b/configuration/service_discovery-section.md
@@ -46,5 +46,4 @@ The `@type` parameter specifies the type of service discovery plugin.
 </service_discovery>
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/configuration/storage-section.md
+++ b/configuration/storage-section.md
@@ -38,5 +38,4 @@ Third-party plugins may also be installed and configured.
 
 For more details, see plugins documentation.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/configuration/transport-section.md
+++ b/configuration/transport-section.md
@@ -116,5 +116,4 @@ For `<transport tls>`:
 * `generate_cert_digest`: \[enum: `sha1`/`sha256`/`sha384`/`sha512`\]
   * Default: `sha256`
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/container-deployment/docker-compose.md
+++ b/container-deployment/docker-compose.md
@@ -175,5 +175,4 @@ The code is available at [https://github.com/digikin/fluentd-elastic-kibana](htt
 * [Fluentd: Get Started](../quickstart/)
 * [Downloading Fluentd](http://www.fluentd.org/download)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/container-deployment/docker-logging-driver.md
+++ b/container-deployment/docker-logging-driver.md
@@ -202,5 +202,4 @@ In a production environment, you must use one of the container orchestration too
 
 * [Kubernetes Logging Overview](https://kubernetes.io/docs/user-guide/logging/overview/)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/container-deployment/install-by-docker.md
+++ b/container-deployment/install-by-docker.md
@@ -114,5 +114,4 @@ Also, refer to the following tutorials to learn how to collect data from various
   * [Store Apache Log into MongoDB](../how-to-guides/apache-to-mongodb.md)
   * [Data Collection into HDFS](../how-to-guides/http-to-hdfs.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/container-deployment/kubernetes.md
+++ b/container-deployment/kubernetes.md
@@ -105,5 +105,4 @@ This YAML file contains two relevant environment variables that are used by Flue
 
 Any relevant change needs to be done in the YAML file before deployment. The defaults assume that at least one Elasticsearch Pod **elasticsearch-logging** exists in the cluster.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/command-line-option.md
+++ b/deployment/command-line-option.md
@@ -178,5 +178,4 @@ fluent-ctl shutdown 11111
 
 Control Linux Capability for Fluentd. See [Linux Capability](linux-capability.md) article.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/failure-scenarios.md
+++ b/deployment/failure-scenarios.md
@@ -34,5 +34,4 @@ If the storage destination \(e.g. Amazon S3, MongoDB, HDFS, etc.\) goes down, Fl
 
 If you're using [`buf_memory`](../buffer/memory.md), the aggregators will stop accepting new logs once they reach their buffer limits. If you are using [`buf_file`](../buffer/file.md), the aggregators will continue accepting logs until they run out of disk space.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/fluentd-ui.md
+++ b/deployment/fluentd-ui.md
@@ -77,5 +77,4 @@ The default account credentials are:
 
 ![](../.gitbook/assets/05.png)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/high-availability.md
+++ b/deployment/high-availability.md
@@ -149,5 +149,4 @@ $ nmap -p 24224 -sU host
 
 Please note that there is one [known issue](http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2019944) where VMware will occasionally lose small UDP packages used for the heartbeat.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/linux-capability.md
+++ b/deployment/linux-capability.md
@@ -177,5 +177,4 @@ $ bundle exec fluentd -c in_tail_camouflage_permission.conf
 
 Fluentd which is running on ordinal user does not complain as `Permission denied`. Users can retrieve root files' contents on non-root process, yay!
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/logging.md
+++ b/deployment/logging.md
@@ -299,5 +299,4 @@ If an error occurs, you will get a notification message in your Slack `notify` c
 
 You can still use [v0.12 way](https://fluentd.gitbook.io/manual/v/0.12/deployment/logging#capture-fluentd-logs) without `<label @FLUENT_LOG>` but this feature is deprecated. This feature will be removed in fluentd v2.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/multi-process-workers.md
+++ b/deployment/multi-process-workers.md
@@ -252,5 +252,4 @@ You may see following error in the fluentd logs:
 
 This means that the configured plugin does not support multi-process workers. All configured plugins must support multi-process workers. See "Multi-Process Worker and Plugins" section above.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/performance-tuning-single-process.md
+++ b/deployment/performance-tuning-single-process.md
@@ -93,5 +93,4 @@ The CPU is often the bottleneck for Fluentd instances that handle billions of in
 
 For more details on this feature, please read [multi process workers](multi-process-workers.md) article.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/plugin-management.md
+++ b/deployment/plugin-management.md
@@ -160,5 +160,4 @@ fluent-plugin-record-modifier (2.0.1, 0.6.0, 0.5.0)
 
 `2.0.1` version is used.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/rpc.md
+++ b/deployment/rpc.md
@@ -34,5 +34,4 @@ As evident from the output above, each endpoint returns a JSON object as its res
 | `/api/config.gracefulReload` | [SIGUSR2](signals.md#sigusr2) | Reloads configuration. |
 | `/api/config.reload` | [SIGHUP](signals.md#sighup) | Reloads configuration. |
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/signals.md
+++ b/deployment/signals.md
@@ -32,5 +32,4 @@ If you use fluentd v1.9.0 or later, use `SIGUSR2` instead.
 
 Calls SIGDUMP to dump fluentd internal status. See [troubleshooting](trouble-shooting.md#dump-fluentd-internal-information) article.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/system-config.md
+++ b/deployment/system-config.md
@@ -238,5 +238,4 @@ For code example, please refer to [`api-plugin-base`](../plugin-development/api-
 * `-g`, `--gemfile GEMFILE`: Specifies the Gemfile path.
 * `-G`, `--gem-path GEM_INSTALL_PATH`: Specifies the Gemfile install path. \(Default: `$(dirname $gemfile)/vendor/bundle`\)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/deployment/trouble-shooting.md
+++ b/deployment/trouble-shooting.md
@@ -93,5 +93,4 @@ If the problem happens inside Ruby e.g. segmentation fault, C extension bug, etc
 $ sudo LD_PRELOAD=/opt/td-agent/embedded/lib/libjemalloc.so /usr/sbin/td-agent -c /etc/td-agent/td-agent.conf --user td-agent --group td-agent
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/filter/README.md
+++ b/filter/README.md
@@ -72,5 +72,4 @@ This is not a critical log message and you can ignore it.
 * [`record_transformer`](record_transformer.md)
 * [`filter_stdout`](stdout.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/filter/geoip.md
+++ b/filter/geoip.md
@@ -176,5 +176,4 @@ Required plugins:
 
 * [`fluent-plugin-geoip`](https://github.com/y-ken/fluent-plugin-geoip)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/filter/grep.md
+++ b/filter/grep.md
@@ -330,5 +330,4 @@ If `<regexp>` and `<exclude>` are used together, both are applied.
 * [Filter Plugin Overview](./)
 * [`record_transformer` Filter Plugin](record_transformer.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/filter/parser.md
+++ b/filter/parser.md
@@ -221,5 +221,4 @@ See also `emit_invalid_record_to_error` parameter.
 
 * [Filter Plugin Overview](./)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/filter/record_transformer.md
+++ b/filter/record_transformer.md
@@ -302,5 +302,4 @@ Without `enable_ruby`, `${}` placeholder supports only double-quoted string for 
 
 * [Filter Plugin Overview](./)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/filter/stdout.md
+++ b/filter/stdout.md
@@ -62,5 +62,4 @@ See [Inject Section Configurations](../configuration/inject-section.md) for more
 
 * [Filter Plugin Overview](./)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/formatter/README.md
+++ b/formatter/README.md
@@ -66,5 +66,4 @@ See [this section](../plugin-development/#text-formatter-plugins) to learn how t
 * [`out_file`](../output/file.md)
 * [`out_s3`](../output/s3.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/formatter/csv.md
+++ b/formatter/csv.md
@@ -90,5 +90,4 @@ In Windows:
 192.168.0.1,PUT\r\n
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/formatter/hash.md
+++ b/formatter/hash.md
@@ -39,5 +39,4 @@ This incoming event is formatted to:
 {"host"=>"192.168.0.1","size"=>777,"method"=>"PUT"}
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/formatter/json.md
+++ b/formatter/json.md
@@ -39,5 +39,4 @@ This incoming event is formatted to:
 {"host":"192.168.0.1","size":777,"method":"PUT"}
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/formatter/ltsv.md
+++ b/formatter/ltsv.md
@@ -73,5 +73,4 @@ In Windows:
 host:192.168.0.1\tsize:777\tmethod:PUT\r\n
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/formatter/msgpack.md
+++ b/formatter/msgpack.md
@@ -21,5 +21,4 @@ This incoming event is formatted to:
 \x83\xA4host\xAB192.168.0.1\xA4size\xCD\x03\t\xA6method\xA3PUT
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/formatter/out_file.md
+++ b/formatter/out_file.md
@@ -77,5 +77,4 @@ This incoming event is formatted to:
 2013-02-28T12:00:00+09:00\tapp.event\t{"host":"192.168.0.1","size":777,"method":"PUT"}
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/formatter/single_value.md
+++ b/formatter/single_value.md
@@ -55,5 +55,4 @@ In Windows:
 Hello from Fluentd!\r\n
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/formatter/stdout.md
+++ b/formatter/stdout.md
@@ -44,5 +44,4 @@ This incoming event is formatted to:
 2017-11-20 14:44:12 +0900 app.event: {"host":"192.168.0.1","size":777,"method":"PUT"}
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/formatter/tsv.md
+++ b/formatter/tsv.md
@@ -65,5 +65,4 @@ In non-Windows:
 192.168.0.1\t777\tPUT\r\n
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/apache-to-minio.md
+++ b/how-to-guides/apache-to-minio.md
@@ -88,5 +88,4 @@ Wait until the data gets flushed from the buffer \(you can adjust the flush inte
 * [Fluentd Architecture](http://www.fluentd.org/architecture)
 * [Amazon S3 Output plugin](../output/s3.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/apache-to-mongodb.md
+++ b/how-to-guides/apache-to-mongodb.md
@@ -150,5 +150,4 @@ Fluentd + MongoDB makes real-time log collection simple, easy, and robust.
 * [MongoDB Output Plugin](../output/mongo.md)
 * [MongoDB ReplicaSet Output Plugin](../output/mongo_replset.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/apache-to-s3.md
+++ b/how-to-guides/apache-to-s3.md
@@ -122,5 +122,4 @@ Fluentd + Amazon S3 makes real-time log archiving simple.
 * [Fluentd Get Started](../quickstart/)
 * [Amazon S3 Output plugin](../output/s3.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/cep-norikra.md
+++ b/how-to-guides/cep-norikra.md
@@ -201,5 +201,4 @@ We can create a stream data processing platform without any schema definitions, 
 * [Norikra: Query Examples](https://norikra.github.io/examples.html)
 * [Slides: fluent-plugin-norikra](https://www.slideshare.net/tagomoris/fluentpluginnorikra-fluentdcasual)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/filter-modify-apache.md
+++ b/how-to-guides/filter-modify-apache.md
@@ -80,5 +80,4 @@ This will produce an event like this:
 
 Note that `${hostname}` is a predefined variable supplied by the plugin. You can also define a custom variable, or even evaluate arbitrary ruby expressions. For more details, see [`record_transformer`](../filter/record_transformer.md).
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/free-alternative-to-splunk-by-fluentd.md
+++ b/how-to-guides/free-alternative-to-splunk-by-fluentd.md
@@ -177,5 +177,4 @@ If you will be using these components in production, you may want to modify some
 * [Fluentd Get Started](../quickstart/)
 * [Downloading Fluentd](http://www.fluentd.org/download)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/graylog2.md
+++ b/how-to-guides/graylog2.md
@@ -137,5 +137,4 @@ When you log back into Graylog, you should be seeing a graph like this \(wait fo
 
 ![Graylog Graph](../.gitbook/assets/graylog2-graph.png)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/http-to-hdfs.md
+++ b/how-to-guides/http-to-hdfs.md
@@ -124,5 +124,4 @@ Fluentd with WebHDFS makes the realtime log collection simple, robust and scalab
 * [WebHDFS Output Plugin](../output/webhdfs.md)
 * [Slides: Fluentd and WebHDFS](http://www.slideshare.net/tagomoris/fluentd-and-webhdfs)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/http-to-td.md
+++ b/how-to-guides/http-to-td.md
@@ -129,5 +129,4 @@ Fluentd + Treasure Data gives you a data collection and analysis system in days,
 * [Treasure Data](http://www.fluentd.org/treasuredata)
 * [Treasure Data: Documentation](http://docs.treasuredata.com/)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/kinesis-stream.md
+++ b/how-to-guides/kinesis-stream.md
@@ -160,5 +160,4 @@ Fluentd with Amazon Kinesis makes the realtime log collection simple, easy, and 
 * [Amazon Kinesis](https://aws.amazon.com/kinesis/)
 * [Amazon Kinesis Output Plugin](https://github.com/awslabs/aws-fluent-plugin-kinesis) \(Made by Amazon Web Services\)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/logs-to-sematext.md
+++ b/how-to-guides/logs-to-sematext.md
@@ -156,5 +156,4 @@ You'll get access to storing and searching logs from infrastructure, apps, and s
 * [Downloading Fluentd](http://www.fluentd.org/download)
 * [Set up Fluentd with Sematext](https://apps.sematext.com/ui/howto/Logsene/fluentd?activeSection=fluentd)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/parse-syslog.md
+++ b/how-to-guides/parse-syslog.md
@@ -164,5 +164,4 @@ There it is, as you can see in the line!
 
 Fluentd makes it easy to ingest `syslog` events. You can immediately send data to the output systems like MongoDB and Elasticsearch, but also you can do filtering and further parsing _inside Fluentd_ before passing the processed data onto the output destinations.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/raspberrypi-cloud-data-logger.md
+++ b/how-to-guides/raspberrypi-cloud-data-logger.md
@@ -91,5 +91,4 @@ SELECT SUM(sensor2) FROM raspberrypi;
 
 Raspberry Pi is an ideal platform for prototyping data logger hardware. Fluentd helps Raspberry Pi transfer the collected data to the cloud easily and reliably.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/splunk-like-grep-and-alert-email.md
+++ b/how-to-guides/splunk-like-grep-and-alert-email.md
@@ -123,5 +123,4 @@ You can learn more about Fluentd and its plugins by:
 * asking questions on the [mailing list](https://groups.google.com/forum/#!forum/fluentd)
 * [signing up for our newsletters](https://www.fluentd.org/newsletter)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/how-to-guides/syslog-influxdb.md
+++ b/how-to-guides/syslog-influxdb.md
@@ -155,5 +155,4 @@ Here is another screenshot for the `system.daemon.info` series:
 
 ![Chronograf: Query](../.gitbook/assets/chronograf-query-2.png)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/README.md
+++ b/input/README.md
@@ -36,5 +36,4 @@ Refer to this list of available plugins to find out about other Input plugins:
 
 * [Fluentd plugins](http://fluentd.org/plugin/)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/exec.md
+++ b/input/exec.md
@@ -210,5 +210,4 @@ And if you run Fluentd with it, you will see the following output \(if you are i
 
 Of course, you can use Fluentd's many output plugins to store the data into various backend systems like [Elasticsearch](../how-to-guides/free-alternative-to-splunk-by-fluentd.md), [HDFS](../how-to-guides/http-to-hdfs.md), [MongoDB](../how-to-guides/apache-to-mongodb.md), [AWS](../how-to-guides/apache-to-s3.md), etc.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/forward.md
+++ b/input/forward.md
@@ -445,5 +445,4 @@ With this configuration, the three \(3\) workers share the port `24224`. No need
 
 See [Docker Logging](http://www.fluentd.org/guides/recipes/docker-logging) driver use case.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/http.md
+++ b/input/http.md
@@ -360,5 +360,4 @@ Fluentd supports [TLS mutual authentication](https://en.wikipedia.org/wiki/Mutua
 
 When this feature is enabled, Fluentd will check all the incoming requests for a client certificate signed by the trusted CA. Requests with an invalid client certificate will fail.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/monitor_agent.md
+++ b/input/monitor_agent.md
@@ -238,5 +238,4 @@ Three \(3\) HTTP servers will be launched with:
 
 Note that you may need to set `worker_id` to `@id` parameter. See [config article](../configuration/config-file.md#embedded-ruby-code).
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/sample.md
+++ b/input/sample.md
@@ -101,5 +101,4 @@ The sample data to be generated. It should be either an array of JSON hashes or 
 
 If you use fluentd v1.11.1 or earlier, use `dummy`.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/syslog.md
+++ b/input/syslog.md
@@ -364,5 +364,4 @@ If other parts are different, the `syslog` parser cannot parse your message. To 
 
 * [Input Plugin Overview](./)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/tail.md
+++ b/input/tail.md
@@ -443,5 +443,4 @@ path C:/path/to/*/foo.log
 path C:\\path\\to\\*\\foo.log
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/tcp.md
+++ b/input/tcp.md
@@ -260,5 +260,4 @@ $ openssl s_client -connect localhost:20001 \
 
 If the connection gets established successfully, your setup is working fine.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/udp.md
+++ b/input/udp.md
@@ -185,5 +185,4 @@ For example, suppose you intend to receive packets which contain the following d
 
 you need to be careful that the default behaviour of Fluentd is to trim the 6th byte \(`0x0a`\) from payload. If you do not want this behaviour, please configure `remove_newline` to `false`.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/unix.md
+++ b/input/unix.md
@@ -47,5 +47,4 @@ The backlog of Unix Domain Socket.
 
 `in_unix` uses incoming event's tag by default. If the `tag` parameter is set, its value is used instead.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/input/windows_eventlog.md
+++ b/input/windows_eventlog.md
@@ -118,5 +118,4 @@ This page does not describe all the possible configurations. If you want to know
 
 * [`fluent-plugin-windows-eventlog`](https://github.com/fluent/fluent-plugin-windows-eventlog)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/installation/before-install.md
+++ b/installation/before-install.md
@@ -76,3 +76,5 @@ If you turned off these protection, please turn on them.
 Use `sysctl -p` command or reboot your node for the changes to take effect.
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
+
+{% include "../.gitbook/assets/footer.txt" %}

--- a/installation/install-by-deb.md
+++ b/installation/install-by-deb.md
@@ -250,5 +250,4 @@ For further steps, follow these:
 * [ChangeLog of `td-agent`](https://docs.treasuredata.com/display/public/PD/The+td-agent+Change+Log)
 * [Chef Cookbook](https://github.com/treasure-data/chef-td-agent/)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/installation/install-by-dmg.md
+++ b/installation/install-by-dmg.md
@@ -141,5 +141,4 @@ For further steps, follow these:
 * [ChangeLog of `td-agent`](https://docs.treasuredata.com/display/public/PD/The+td-agent+Change+Log)
 * [Chef Cookbook](https://github.com/treasure-data/chef-td-agent/)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/installation/install-by-gem.md
+++ b/installation/install-by-gem.md
@@ -63,5 +63,4 @@ You are now ready to collect real logs with Fluentd. Refer to the following tuto
   * [Store Apache Log into MongoDB](../how-to-guides/apache-to-mongodb.md)
   * [Data Collection into HDFS](../how-to-guides/http-to-hdfs.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/installation/install-by-msi.md
+++ b/installation/install-by-msi.md
@@ -334,5 +334,4 @@ For further steps, follow these:
 * [ChangeLog of td-agent](https://docs.treasuredata.com/display/public/PD/The+td-agent+Change+Log)
 * [Chef Cookbook](https://github.com/treasure-data/chef-td-agent/)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/installation/install-by-rpm.md
+++ b/installation/install-by-rpm.md
@@ -226,5 +226,4 @@ For further steps, follow these:
 * [ChangeLog of td-agent](https://docs.treasuredata.com/display/public/PD/The+td-agent+Change+Log)
 * [Chef Cookbook](https://github.com/treasure-data/chef-td-agent/)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/installation/install-from-source.md
+++ b/installation/install-from-source.md
@@ -86,5 +86,4 @@ You are now ready to collect real logs with Fluentd. Refer to the following tuto
   * [Store Apache Log into MongoDB](../how-to-guides/apache-to-mongodb.md)
   * [Data Collection into HDFS](../how-to-guides/http-to-hdfs.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/installation/post-installation-guide.md
+++ b/installation/post-installation-guide.md
@@ -154,5 +154,4 @@ To catch all the descendent tags, use double asterisks `**`. For example, `debug
 
 * [Configuration File Syntax](../configuration/config-file.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/language-bindings/java.md
+++ b/language-bindings/java.md
@@ -119,5 +119,4 @@ Monitoring Fluentd itself is also important. The article below describes the gen
 
 * [Monitoring Fluentd](../monitoring-fluentd/overview.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/language-bindings/nodejs.md
+++ b/language-bindings/nodejs.md
@@ -136,5 +136,4 @@ Monitoring Fluentd itself is also important. The article below describes the gen
 
 * [Monitoring Fluentd](../monitoring-fluentd/overview.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/language-bindings/perl.md
+++ b/language-bindings/perl.md
@@ -102,5 +102,4 @@ Monitoring Fluentd itself is also important. The article below describes the gen
 
 * [Monitoring Fluentd](../monitoring-fluentd/overview.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/language-bindings/php.md
+++ b/language-bindings/php.md
@@ -102,5 +102,4 @@ Monitoring Fluentd itself is also important. The article below describes the gen
 
 * [Monitoring Fluentd](../monitoring-fluentd/overview.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/language-bindings/python.md
+++ b/language-bindings/python.md
@@ -101,5 +101,4 @@ Monitoring Fluentd itself is also important. The article below describes the gen
 
 * [Monitoring Fluentd](../monitoring-fluentd/overview.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/language-bindings/ruby.md
+++ b/language-bindings/ruby.md
@@ -96,5 +96,4 @@ Monitoring Fluentd itself is also important. The article below describes the gen
 
 * [Monitoring Fluentd](../monitoring-fluentd/overview.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/language-bindings/scala.md
+++ b/language-bindings/scala.md
@@ -125,5 +125,4 @@ Monitoring Fluentd itself is also important. The article below describes the gen
 
 * [Monitoring Fluentd](../monitoring-fluentd/overview.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/monitoring-fluentd/monitoring-prometheus.md
+++ b/monitoring-fluentd/monitoring-prometheus.md
@@ -266,5 +266,4 @@ For more advanced visualization and alerting, we recommend [Grafana](https://gra
 * [Prometheus Documentation](https://prometheus.io/docs/introduction/overview/)
 * [Grafana Documentation](http://docs.grafana.org/)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/monitoring-fluentd/monitoring-rest-api.md
+++ b/monitoring-fluentd/monitoring-rest-api.md
@@ -69,5 +69,4 @@ For more details:
 
 * [Datadog-Fluentd Integration](http://docs.datadoghq.com/integrations/fluentd/)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/monitoring-fluentd/overview.md
+++ b/monitoring-fluentd/overview.md
@@ -53,5 +53,4 @@ A debug port for local communication is recommended for troubleshooting. The fol
 
 You can attach the process using the `fluent-debug` command through `dRuby`.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/README.md
+++ b/output/README.md
@@ -267,5 +267,4 @@ This example sends logs to Elasticsearch using a file buffer `/var/log/td-agent/
 
 NOTE: `<secondary>` plugin receives the primary's buffer chunk directly. So, you need to check if your secondary plugin works with the primary setting.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/copy.md
+++ b/output/copy.md
@@ -169,5 +169,4 @@ Since Fluentd v1.12.2, you can use `ignore_if_prev_successes` to define fallback
 
 Fluentd will make use of plugin2 only if the preceeding destinations \(plugin1 in this case\) fail.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/elasticsearch.md
+++ b/output/elasticsearch.md
@@ -162,5 +162,4 @@ Please refer to the [Elasticsearch's troubleshooting](https://github.com/uken/fl
 
 * [`fluent-plugin-elasticsearch`](https://github.com/uken/fluent-plugin-elasticsearch)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/exec.md
+++ b/output/exec.md
@@ -200,5 +200,4 @@ See [Buffer Section](../configuration/buffer-section.md) for more details.
 
 Overwrites the default value in this plugin.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/exec_filter.md
+++ b/output/exec_filter.md
@@ -266,5 +266,4 @@ Corresponding configuration:
 
 You may convert this script into your preferred language accordingly.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/file.md
+++ b/output/file.md
@@ -231,5 +231,4 @@ $ tree /tmp/logs/
 └── current-dummy2 -> /tmp/logs/${tag}/buffer.b57fb1dd96306dd0b308e094f7ec2228f.log
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/forward.md
+++ b/output/forward.md
@@ -640,5 +640,4 @@ $ nmap -p 24224 -sU host
 
 Please note that there is one [known issue](http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2019944) where VMware will occasionally lose small UDP packets used for heartbeat.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/http.md
+++ b/output/http.md
@@ -402,5 +402,4 @@ And, receiver `in_http` configuration should be:
 
 But, we recommend to use in/out [`forward`](forward.md) plugin to communicate with two Fluentd instances due to `at-most-once` and `at-least-once` semantics for rigidity.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open article- source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/kafka.md
+++ b/output/kafka.md
@@ -138,5 +138,4 @@ This page does not describe all the possible configurations. If you want to know
 
 * [`fluent-plugin-kafka`](https://github.com/fluent/fluent-plugin-kafka)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/mongo.md
+++ b/output/mongo.md
@@ -190,5 +190,4 @@ For common output / buffer parameters, please check the following articles:
 
 * [`fluent-plugin-mongo`](https://github.com/fluent/fluent-plugin-mongo)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/mongo_replset.md
+++ b/output/mongo_replset.md
@@ -174,5 +174,4 @@ For common output / buffer parameters, please check the following articles:
 
 * [`fluent-plugin-webhdfs mongo`](https://github.com/fluent/fluent-plugin-mongo)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/null.md
+++ b/output/null.md
@@ -72,5 +72,4 @@ Overwrites the default value in this plugin.
 
 See [Buffer Plugin Overview](../buffer/) and [Output Plugin Overview](./).
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/relabel.md
+++ b/output/relabel.md
@@ -48,5 +48,4 @@ The value must be `relabel`.
 
 Specifies the label. It is a required parameter.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/rewrite_tag_filter.md
+++ b/output/rewrite_tag_filter.md
@@ -504,5 +504,4 @@ In this case, `rewrite_tag_filter` causes an infinite loop because the fluentd's
 </match>
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/roundrobin.md
+++ b/output/roundrobin.md
@@ -57,5 +57,4 @@ Specifies the storage destinations. The format is the same as the `<match>` dire
 
 Weight to distribute events to multiple outputs.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/s3.md
+++ b/output/s3.md
@@ -190,5 +190,4 @@ This page does not describe all the possible configurations. For more details, f
 
 * [`fluent-plugin-s3`](https://github.com/fluent/fluent-plugin-s3)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/secondary_file.md
+++ b/output/secondary_file.md
@@ -111,5 +111,4 @@ $ cat /path/to/dump.bin.0 | fluent-cat --format msgpack  --host 127.0.0.1 --port
 
 See [fluent-cat](../deployment/command-line-option.md#fluent-cat) command line option about details.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/stdout.md
+++ b/output/stdout.md
@@ -95,5 +95,4 @@ This is the option for the `stdout` format. Configure the format of the record \
 
 See [Inject Section Configurations](../configuration/inject-section.md) for more details.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/output/webhdfs.md
+++ b/output/webhdfs.md
@@ -154,5 +154,4 @@ For common output / buffer parameters, please check the following articles:
 * [`fluent-plugin-webhdfs`](https://github.com/fluent/fluent-plugin-webhdfs)
 * [Slides: Fluentd and WebHDFS](http://www.slideshare.net/tagomoris/fluentd-and-webhdfs)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/README.md
+++ b/parser/README.md
@@ -83,5 +83,4 @@ Following plugins support `<parse>` directive:
 * [`in_syslog`](../input/syslog.md)
 * [`in_http`](../input/http.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/apache2.md
+++ b/parser/apache2.md
@@ -46,5 +46,4 @@ record:
 }
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/apache_error.md
+++ b/parser/apache_error.md
@@ -38,5 +38,4 @@ record:
 }
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/csv.md
+++ b/parser/csv.md
@@ -92,5 +92,4 @@ record:
 
 If you set `null_value_pattern '-'` in the configuration, `user` field becomes `nil` instead of `"-"`.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/json.md
+++ b/parser/json.md
@@ -70,5 +70,4 @@ record:
 }
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/ltsv.md
+++ b/parser/ltsv.md
@@ -86,5 +86,4 @@ record:
 }
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/msgpack.md
+++ b/parser/msgpack.md
@@ -24,5 +24,4 @@ record:
 {"message":"Hello msgpack", "num":100}
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/multiline.md
+++ b/parser/multiline.md
@@ -126,5 +126,4 @@ record:
 }
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/nginx.md
+++ b/parser/nginx.md
@@ -46,5 +46,4 @@ record:
 }
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/none.md
+++ b/parser/none.md
@@ -34,5 +34,4 @@ record:
 {"message":"Hello world. I am a line of log!"}
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/regexp.md
+++ b/parser/regexp.md
@@ -109,5 +109,4 @@ record:
 
 NOTE: You may hit Application Error at Fluentular due to [heroku's free plan limitation](https://www.heroku.com/pricing). Retry a few hours later or use `fluentd-ui` instead.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/syslog.md
+++ b/parser/syslog.md
@@ -155,5 +155,4 @@ record:
 }
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/parser/tsv.md
+++ b/parser/tsv.md
@@ -56,5 +56,4 @@ record:
 
 If you set `null_value_pattern '-'` in the configuration, `user` field becomes `nil` instead of `"-"`.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/README.md
+++ b/plugin-development/README.md
@@ -331,5 +331,4 @@ For more details, see `fluent-plugin-config-format --help`.
 
   \(outdated\)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/api-config-types.md
+++ b/plugin-development/api-config-types.md
@@ -344,5 +344,4 @@ This configurations will be converted to:
 { key1: "value1", key2: "value2" }
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/api-plugin-base.md
+++ b/plugin-development/api-plugin-base.md
@@ -433,5 +433,4 @@ Provides a unique ID string for the plugin instance. It might be specified by us
 
 Indicates whether `#plugin_id` is configured by users or not.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/api-plugin-buffer.md
+++ b/plugin-development/api-plugin-buffer.md
@@ -2,5 +2,4 @@
 
 TODO: Write
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/api-plugin-filter.md
+++ b/plugin-development/api-plugin-filter.md
@@ -207,5 +207,4 @@ For:
 
 For more details, see [Testing API for Plugins](plugin-test-code.md).
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/api-plugin-formatter.md
+++ b/plugin-development/api-plugin-formatter.md
@@ -169,5 +169,4 @@ For:
 
 For more details, see [Testing API for Plugins](plugin-test-code.md).
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/api-plugin-input.md
+++ b/plugin-development/api-plugin-input.md
@@ -196,5 +196,4 @@ For:
 * configuration tests, repeat steps \# 1-2
 * full feature tests, repeat steps \# 1-5
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/api-plugin-output.md
+++ b/plugin-development/api-plugin-output.md
@@ -596,5 +596,4 @@ class YourOwnOutputTest < Test::Unit::TestCase
 end
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/api-plugin-parser.md
+++ b/plugin-development/api-plugin-parser.md
@@ -197,5 +197,4 @@ For:
 
 See [Testing API for Plugins](plugin-test-code.md) for details.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/api-plugin-service_discovery.md
+++ b/plugin-development/api-plugin-service_discovery.md
@@ -2,5 +2,4 @@
 
 TODO: Write
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/api-plugin-storage.md
+++ b/plugin-development/api-plugin-storage.md
@@ -2,5 +2,4 @@
 
 TODO: Write
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/plugin-test-code.md
+++ b/plugin-development/plugin-test-code.md
@@ -886,5 +886,4 @@ assert do
 end
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-development/plugin-update-from-v0.12.md
+++ b/plugin-development/plugin-update-from-v0.12.md
@@ -683,5 +683,4 @@ class SomeOutputTest < Test::Unit::TestCase
 end
 ```
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/README.md
+++ b/plugin-helper-overview/README.md
@@ -32,5 +32,4 @@ It will include `Timer`, `Storage`. and `CompatParameters` plugin helpers.
 * [`timer`](api-plugin-helper-timer.md)
 * [`http_server`](api-plugin-helper-http_server.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-child_process.md
+++ b/plugin-helper-overview/api-plugin-helper-child_process.md
@@ -77,5 +77,4 @@ end
 * [`out_exec`](../output/exec.md)
 * [`out_exec_filter`](../output/exec_filter.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-compat_parameters.md
+++ b/plugin-helper-overview/api-plugin-helper-compat_parameters.md
@@ -269,5 +269,4 @@ For more details, see [Formatter Plugin Overview](../formatter/) and [Writing Fo
 * [`out_forward`](../output/forward.md)
 * [`out_stdout`](../output/stdout.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-event_emitter.md
+++ b/plugin-helper-overview/api-plugin-helper-event_emitter.md
@@ -57,5 +57,4 @@ end
 * [`out_copy`](../output/copy.md)
 * [`out_roundrobin`](../output/roundrobin.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-event_loop.md
+++ b/plugin-helper-overview/api-plugin-helper-event_loop.md
@@ -42,5 +42,4 @@ This method attaches watcher to the event loop.
 * [`in_http`](../input/http.md)
 * [`in_tail`](../input/tail.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-extract.md
+++ b/plugin-helper-overview/api-plugin-helper-extract.md
@@ -56,5 +56,4 @@ new_time = extract_time_from_record(record)
 * [`in_udp`](../input/udp.md)
 * [`out_exec_filter`](../output/exec_filter.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-formatter.md
+++ b/plugin-helper-overview/api-plugin-helper-formatter.md
@@ -97,5 +97,4 @@ end
 * [`out_file`](../output/file.md)
 * [`out_s3`](../output/s3.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-http_server.md
+++ b/plugin-helper-overview/api-plugin-helper-http_server.md
@@ -127,5 +127,4 @@ end
 
 * [`in_monitor_agent`](../input/monitor_agent.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-inject.md
+++ b/plugin-helper-overview/api-plugin-helper-inject.md
@@ -72,5 +72,4 @@ end
 * [`out_file`](../output/file.md)
 * [`out_stdout`](../output/stdout.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-parser.md
+++ b/plugin-helper-overview/api-plugin-helper-parser.md
@@ -90,5 +90,4 @@ end
 * [`in_udp`](../input/udp.md)
 * [`out_exec_filter`](../output/exec_filter.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-record_accessor.md
+++ b/plugin-helper-overview/api-plugin-helper-record_accessor.md
@@ -82,5 +82,4 @@ NOTE: `set` method is supported since v1.10.3
 * [`filter_parser`](../filter/parser.md)
 * [`filter_record_transformer`](../filter/record_transformer.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-server.md
+++ b/plugin-helper-overview/api-plugin-helper-server.md
@@ -289,5 +289,4 @@ Fluent::Plugin::InForwardCNChecker.new
 * [`in_udp`](../input/udp.md)
 * [`out_forward`](../output/forward.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-service_discovery.md
+++ b/plugin-helper-overview/api-plugin-helper-service_discovery.md
@@ -132,5 +132,4 @@ You can also use helper methods such as `service_discovery_services` or `service
 `@discovery_manager.services` or `@discovery_manager.rebalance`.
 
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-socket.md
+++ b/plugin-helper-overview/api-plugin-helper-socket.md
@@ -152,5 +152,4 @@ If block is given, it will be invoked with the socket instance as a parameter, a
 
 * [`out_forward`](../output/forward.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-storage.md
+++ b/plugin-helper-overview/api-plugin-helper-storage.md
@@ -142,5 +142,4 @@ This method updates the stored value using a `Proc` object.
 * [`in_sample`](../input/sample.md)
 * [`in_windows_eventlog`](../input/windows_eventlog.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-thread.md
+++ b/plugin-helper-overview/api-plugin-helper-thread.md
@@ -71,5 +71,4 @@ thread_create(:example_plugin_main) {
 * [`in_monitor_agent`](../input/monitor_agent.md)
 * [`in_sample`](../input/sample.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugin-helper-overview/api-plugin-helper-timer.md
+++ b/plugin-helper-overview/api-plugin-helper-timer.md
@@ -61,5 +61,4 @@ end
 * [`in_monitor_agent`](../input/monitor_agent.md)
 * [`in_sample`](../input/sample.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/plugins/input/dummy.md
+++ b/plugins/input/dummy.md
@@ -17,8 +17,4 @@ Fluentd v2 will remove this plugin name.
 
 ------------------------------------------------------------------------
 
-If this article is incorrect or outdated, or omits critical information, please
-[let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open).
-[Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native
-Computing Foundation (CNCF)](https://cncf.io/). All components are available
-under the Apache 2 License.
+{% include "../../.gitbook/assets/footer.txt" %}

--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -54,5 +54,4 @@ The following articles will provide detailed information about Fluentd:
 * [High Availability Configuration](../deployment/high-availability.md)
 * [FAQ](faq.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/quickstart/faq.md
+++ b/quickstart/faq.md
@@ -115,5 +115,4 @@ If you are willing to write Regexp, [fluentd-ui's `in_tail` editor](../deploymen
 
 If you do NOT want to write any Regexp, look at [the Grok parser](https://github.com/kiyoto/fluent-plugin-grok-parser).
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/quickstart/life-of-a-fluentd-event.md
+++ b/quickstart/life-of-a-fluentd-event.md
@@ -232,5 +232,4 @@ Once the events are reported by the [Fluentd](http://fluend.org) engine on the *
 * [Fluentd v0.14 Blog Announcement](http://www.fluentd.org/blog/fluentd-v0.14.0-has-been-released)
 * [Fluentd v1.0 Blog Announcement](http://www.fluentd.org/blog/fluentd-v1.0)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/quickstart/logo.md
+++ b/quickstart/logo.md
@@ -25,5 +25,4 @@ Feel free to use these logos on your slides, blog posts, etc.
 * [Fluentd.ai](https://github.com/fluent/fluentd-docs-gitbook/tree/53020426cdcfcb5a5f722031838ee1cb95b5a7a2/images/logo/Fluentd.ai)
 * [Complete List of Logos](https://github.com/fluent/fluentd-docs-gitbook/tree/1.0/images/logo)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/quickstart/support.md
+++ b/quickstart/support.md
@@ -43,5 +43,4 @@ The source code is available at GitHub:
 
 * [Fluentd](https://github.com/fluent/fluentd/)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/quickstart/td-agent-v2-vs-v3-vs-v4.md
+++ b/quickstart/td-agent-v2-vs-v3-vs-v4.md
@@ -55,5 +55,4 @@ This is for v0.12 and old distribution users. We don't recommend this version fo
 * [macOS](../installation/install-by-dmg.md)
 * [RubyGems](../installation/install-by-gem.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/quickstart/update-from-v0.12.md
+++ b/quickstart/update-from-v0.12.md
@@ -85,5 +85,4 @@ Fluentd v1 changes buffer mechanism for flexibility. The new buffer consists of 
 
 Log forwarding from v0.12 to v1.0 is no problem but log forwarding from v1.0 to v0.12 has a problem due to timestamp change. See [`in_forward`'s FAQ](https://fluentd.gitbook.io/manual/v/0.12/input/forward#i-got-messagepack-unknownexttypeerror-error-why)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/service_discovery/README.md
+++ b/service_discovery/README.md
@@ -42,5 +42,4 @@ Here is a simple example to update target by reading file \(`/etc/fluentd/sd.yam
 
 * [`out_forward`](../output/forward.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/service_discovery/file.md
+++ b/service_discovery/file.md
@@ -130,5 +130,4 @@ The password for authentication.
 | :--- | :--- | :--- |
 | integer | 60 | 1.8.0 |
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/service_discovery/srv.md
+++ b/service_discovery/srv.md
@@ -99,5 +99,4 @@ The username for authentication.
 
 The password for authentication.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/service_discovery/static.md
+++ b/service_discovery/static.md
@@ -85,5 +85,4 @@ The password for authentication.
 | :--- | :--- | :--- |
 | integer | 60 | 1.8.0 |
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/storage/README.md
+++ b/storage/README.md
@@ -57,5 +57,4 @@ NOTE: This 3rd party plugin list does not fully covers all of them.
 * [fluent-plugin-systemd](https://github.com/fluent-plugin-systemd/fluent-plugin-systemd)
 * [fluent-plugin-windows-eventlog](https://github.com/fluent/fluent-plugin-windows-eventlog)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}

--- a/storage/local.md
+++ b/storage/local.md
@@ -59,5 +59,4 @@ With this configuration:
 
 The above configuration will save the internal states such as `auto_increment_value` to `storage/sample.json`. As a result, you can resume from the next value of previous `count` when restarting fluentd.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-
+{% include "../.gitbook/assets/footer.txt" %}


### PR DESCRIPTION
If we need to modify footer content in each page, we should also
modify ~180 page files.
It seems better to split it into asset file.

For example, there is a case that footer content is displayed in a PR, with `{% %}` directive, it can make it smaller diff.
https://github.com/fluent/fluentd-docs-gitbook/pull/318/files