### PR TITLE
in_http: add use_204_response

### DIFF
--- a/input/http.md
+++ b/input/http.md
@@ -144,6 +144,14 @@ Example:
 
 Responds with an empty GIF image of 1x1 pixel \(rather than an empty string\).
 
+### `use_204_response`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| bool | false | v1.8.0 |
+
+Respond status code with 204. This option will be deprecated at v2 because fluentd v2 will respond 204 as default.
+
 ### `<transport>` Section
 
 | type | default | available values | version |


### PR DESCRIPTION
I added missing `use_204_response`.

- Fluentd Pull Request: 
  - https://github.com/fluent/fluentd/pull/2640
- Commit: 
  - https://github.com/fluent/fluentd/commit/ee2ae7b0178ec1f13e53ff18d35e7b5818bc55b1
  - It means the option is supported from v1.8.0
- Note:
  - The option will be deprecated at v2. See also https://github.com/fluent/fluentd/pull/2640#issuecomment-539439936 