### PR TITLE
fix 'path' parameter style

### DIFF
--- a/output/elasticsearch.md
+++ b/output/elasticsearch.md
@@ -77,7 +77,7 @@ password mysecret
 
 Specify `https` if your Elasticsearch endpoint supports SSL \(default: `http`\).
 
-### path \(optional\)
+### `path` \(optional\)
 
 The REST API endpoint of Elasticsearch to post write requests \(default: `nil`\).
 


### PR DESCRIPTION
https://docs.fluentd.org/output/elasticsearch#path-optional

I modified a style of 'path' parameter.
I added missing backquotes.