### PR TITLE
in_syslog: Add a new & a missing parameter

### DIFF
--- a/input/syslog.md
+++ b/input/syslog.md
@@ -247,6 +247,14 @@ Emitted record is `{"unmatched_line" : "incoming line"}` with `${tag parameter}.
 
 Tries to resolve hostname from IP addresses or not. Cannot set `false` when `source_hostname_key` is set.
 
+### `send_keepalive_packet`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| bool | false | 1.14.0 |
+
+Enables the TCP keepalive for sockets. See [socket article](../plugin-helper-overview/api-plugin-helper-socket.md#send_keepalive_packet-usecase) for more details.
+
 ### `source_hostname_key`
 
 | type | default | version |

--- a/input/syslog.md
+++ b/input/syslog.md
@@ -239,6 +239,14 @@ Emits unmatched lines when `<parse>` format is not matched for incoming logs.
 
 Emitted record is `{"unmatched_line" : "incoming line"}` with `${tag parameter}.unmatched` tag.
 
+### `resolve_hostname`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| bool | nil | 0.14.19 |
+
+Tries to resolve hostname from IP addresses or not. Cannot set `false` when `source_hostname_key` is set.
+
 ### `source_hostname_key`
 
 | type | default | version |


### PR DESCRIPTION
* Add a new parameter `send_keepalive_packet`
  * Since 1.14.0: https://github.com/fluent/fluentd/pull/3474
* Add a missing parameter `resolve_hostname`
  * Since 0.14.19: https://github.com/fluent/fluentd/pull/1616