### PR TITLE
1.0: document enable_input_metrics and enable_size_metrics

### DIFF
--- a/deployment/command-line-option.md
+++ b/deployment/command-line-option.md
@@ -35,6 +35,8 @@ Usage: fluentd [options]
         --use-v1-config              Use v1 configuration format (default)
         --use-v0-config              Use v0 configuration format
         --strict-config-value        Parse config values strictly
+        --enable-input-metrics       Enable input plugin metrics on fluentd
+        --enable-size-metrics        Enable plugin record size metrics on fluentd
     -v, --verbose                    increase verbose level (-v: debug, -vv: trace)
     -q, --quiet                      decrease verbose level (-q: warn, -qq: error)
         --suppress-config-dump       suppress config dumping when fluentd starts

--- a/deployment/system-config.md
+++ b/deployment/system-config.md
@@ -190,6 +190,23 @@ Specifies `daily`, `weekly`, `monthly` or integer which indicates age of log rot
 
 Specifies log file size limitation.
 
+#### `enable_input_metrics`
+
+| type | default | version |
+| :--- | :---    | :---    |
+| bool | nil     | 1.14.0  |
+
+Specifies whether measuring input metrics should be enabled or not.
+
+#### `enable_size_metrics`
+
+| type | default | version |
+| :--- | :---    | :---    |
+| bool | nil     | 1.14.0  |
+
+Specifies whether measuring record size metrics should be enabled or not.
+It can be useful for calculating flow rate on Fluentd instances.
+
 ### `Fluent::SystemConfig::Mixin` Methods
 
 #### `.system_config`


### PR DESCRIPTION
In addition to https://github.com/fluent/fluentd-docs-gitbook/pull/347, configuration parameters should be documented.
