### PR TITLE
Update exec_filter.md

### DIFF
--- a/output/exec_filter.md
+++ b/output/exec_filter.md
@@ -169,7 +169,7 @@ Overwrites the default value in this plugin.
 
 | type | default | version |
 | :--- | :--- | :--- |
-| bool | false | 0.14.9 |
+| bool | true | 0.14.9 |
 
 Overwrites the default value in this plugin.
 


### PR DESCRIPTION
exec_filter shows "localtime is false as default".
Ref. https://docs.fluentd.org/output/exec_filter#less-than-parse-greater-than-section

But, config doc shows "localtime (bool) (optional): if true, uses local time. Otherwise, UTC is used. This is exclusive with utc. Default: true"
Ref. https://docs.fluentd.org/configuration/parse-section

In the code, it says true as default.
https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/out_exec_filter.rb#L47

Thus, this change fix the default localtime value in the exec_filter page