### PR TITLE
Fix default value of time_type for parse-section again

### DIFF
--- a/configuration/parse-section.md
+++ b/configuration/parse-section.md
@@ -143,7 +143,7 @@ For the `types` parameter, the following types are supported:
 
   type
 
-  * Default: `float`
+  * Default: `string`
   * Available values: `float`, `unixtime`, `string`, `mixed`
     * `float`: seconds from Epoch + nano seconds \(e.g.
 


### PR DESCRIPTION
Hi.
While reading the documentation, I notice that the default value of time_type which was fixed in #62 has been reverted.

I looked at the source code, and I think the default value is probably the string.
https://github.com/fluent/fluentd/blob/master/lib/fluent/time.rb#L146

Could you please review this PR?