### PR TITLE
Add note for apple/intel packages for Calyptia-Fluentd

### DIFF
--- a/installation/install-by-dmg.md
+++ b/installation/install-by-dmg.md
@@ -78,6 +78,8 @@ Download and install the `.dmg` package:
 * [calyptia-fluentd v1](https://calyptia-fluentd.s3.us-east-2.amazonaws.com/index.html?prefix=1/macos/)
 
 NOTE: If your OS is not supported, consider [gem installation](install-by-gem.md) instead.
+NOTE: Since calyptia-fluentd v1.3.1, intel version and apple silicon version of packages are provided.
+`-intel` suffix is for Intel version and `-apple` suffix is for Apple Silicon.
 
 ### Step 2: Launch `calyptia-fluentd`
 


### PR DESCRIPTION
Intel (traditional architecture) package and Apple (the brand new architecture) package are provided since Calyptia-Fluentd v1.3.1.
I added a note for them.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>