### PR TITLE
1.0: Fix wrong output result about json formatter

### DIFF
--- a/formatter/README.md
+++ b/formatter/README.md
@@ -43,10 +43,10 @@ However, if you set `@type json` in `<format>` like this:
 The output changes to
 
 ```javascript
-{"time": "2014-08-25 00:00:00 +0000", "tag":"foo.bar", "k1":"v1", "k2":"v2"}
+{"k1":"v1", "k2":"v2"}
 ```
 
-i.e., each line is a single JSON object with "time" and "tag fields to retain the event's timestamp and tag.
+i.e., each line is a single JSON object without "time" and "tag" fields. If you want to include "time" and "tag", use [Inject section](../configuration/inject-section.md).
 
 See [this section](../plugin-development/#text-formatter-plugins) to learn how to develop a custom formatter.
 


### PR DESCRIPTION
json formatter doesn't include "time" and "tag" by default.

Closes: #381

