### PR TITLE
Fix the type of null_value_pattern in configuration/parser-section

### DIFF
--- a/configuration/parse-section.md
+++ b/configuration/parse-section.md
@@ -89,7 +89,7 @@ The default value of the following parameters will be overridden by the individu
 
     parameter and set it to `time` by default.
 
-* **`null_value_pattern`** \(string\) \(optional\): Specify null value pattern.
+* **`null_value_pattern`** \(regexp\) \(optional\): Specify null value pattern.
   * Default: `nil`
 * **`null_empty_string`** \(bool\) \(optional\): If `true`, empty string field is
 


### PR DESCRIPTION
`regexp` is appropriate for it.

See also: https://github.com/fluent/fluentd/pull/3650

Signed-off-by: Takuro Ashie <ashie@clear-code.com>