### PR TITLE
1.0: Fix some images linked to GitHub

### DIFF
--- a/buffer/README.md
+++ b/buffer/README.md
@@ -30,7 +30,7 @@ You can think of a chunk as a cargo box. A buffer plugin uses a chunk as a light
 
 Internally, a buffer plugin has two separated places to store its chunks: _"stage"_ where chunks get filled with events, and _"queue"_ where chunks wait before the transportation. Every newly-created chunk starts from _stage_, then proceeds to _queue_ in time \(and subsequently gets transferred to the destination\).
 
-[![Fluentd-v0.14 Plugin API Overview](../.gitbook/assets/fluentd-v0.14-plugin-api-overview.png)](https://github.com/fluent/fluentd-docs-gitbook/tree/da81ba70252eaa863cc28fc888584c59d6fc14d3/images/fluentd-v0.14-plugin-api-overview.png)
+![Fluentd-v0.14 Plugin API Overview](../.gitbook/assets/fluentd-v0.14-plugin-api-overview.png)
 
 ## Control Retry Behavior
 

--- a/installation/install-by-msi.md
+++ b/installation/install-by-msi.md
@@ -164,7 +164,7 @@ It's working properly if td-agent process outputs:
 test.event: {"k", "v"}
 ```
 
-[![Td-agent Windows Prompt](../.gitbook/assets/td-agent-windows-prompt.png)](https://github.com/fluent/fluentd-docs-gitbook/tree/da81ba70252eaa863cc28fc888584c59d6fc14d3/images/td-agent-windows-prompt.png)
+![Td-agent Windows Prompt](../.gitbook/assets/td-agent-windows-prompt.png)
 
 ### Step 3: Register `td-agent` to Windows Service
 


### PR DESCRIPTION
Clicking the image make jump to GitHub page, but this is just annoying,
and this seems to make the sizes of the images smaller.

![Screenshot-from-2022-03-25-14-37-30](https://user-images.githubusercontent.com/12229857/160076343-94ed5d90-109d-4d6a-8876-4cf7f852f69a.png)

