### PR TITLE
Add description to `linger_timeout` behavior about Windows

### DIFF
--- a/input/forward.md
+++ b/input/forward.md
@@ -170,9 +170,11 @@ This section is for setting TLS transport or some general transport configuratio
 
 The timeout \(seconds\) to set `SO_LINGER`.
 
-The default value `0` is to send RST rather than FIN to avoid lots of connections sitting in TIME_WAIT on closing.
+The default value `0` is to send RST rather than FIN to avoid lots of connections sitting in TIME_WAIT on closing on non-Windows.
 
-You can set positive value to send FIN on closing.
+You can set positive value to send FIN on closing on non-Windows.
+
+(On Windows, Fluentd sends FIN when `linger_timeout` is `0` too).
 
 ```text
 <transport tcp>

--- a/input/http.md
+++ b/input/http.md
@@ -178,9 +178,11 @@ This section is for setting TLS transport or some general transport configuratio
 
 The timeout \(seconds\) to set `SO_LINGER`.
 
-The default value `0` is to send RST rather than FIN to avoid lots of connections sitting in TIME_WAIT on closing.
+The default value `0` is to send RST rather than FIN to avoid lots of connections sitting in TIME_WAIT on closing on non-Windows.
 
-You can set positive value to send FIN on closing.
+You can set positive value to send FIN on closing on non-Windows.
+
+(On Windows, Fluentd sends FIN when `linger_timeout` is `0` too).
 
 ```text
 <transport tcp>

--- a/input/tcp.md
+++ b/input/tcp.md
@@ -151,9 +151,11 @@ This section is for setting TLS transport or some general transport configuratio
 
 The timeout \(seconds\) to set `SO_LINGER`.
 
-The default value `0` is to send RST rather than FIN to avoid lots of connections sitting in TIME_WAIT on closing.
+The default value `0` is to send RST rather than FIN to avoid lots of connections sitting in TIME_WAIT on closing on non-Windows.
 
-You can set positive value to send FIN on closing.
+You can set positive value to send FIN on closing on non-Windows.
+
+(On Windows, Fluentd sends FIN when `linger_timeout` is `0` too).
 
 ```text
 <source>

--- a/plugin-helper-overview/api-plugin-helper-server.md
+++ b/plugin-helper-overview/api-plugin-helper-server.md
@@ -170,9 +170,11 @@ end
 
 The timeout \(seconds\) to set `SO_LINGER`.
 
-The default value `0` is to send RST rather than FIN to avoid lots of connections sitting in TIME_WAIT on closing.
+The default value `0` is to send RST rather than FIN to avoid lots of connections sitting in TIME_WAIT on closing on non-Windows.
 
-You can set positive value to send FIN on closing.
+You can set positive value to send FIN on closing on non-Windows.
+
+(On Windows, Fluentd sends FIN when `linger_timeout` is `0` too).
 
 ```text
 <source>


### PR DESCRIPTION
This is corresponding to https://github.com/fluent/fluentd/pull/3701

This option is added in https://github.com/fluent/fluentd/pull/3644
and the description is added in https://github.com/fluent/fluentd-docs-gitbook/pull/392

There was a lack of consideration regarding the default behavior on Windows.

This fixes it.