### PR TITLE
Fix inaccuracy in UDP input parse section

### DIFF
--- a/input/udp.md
+++ b/input/udp.md
@@ -141,7 +141,7 @@ Removes the newline from the end of the incoming payload.
 | :--- | :--- | :--- |
 | true | false | 0.14.10 |
 
-`in_tcp` uses the parser plugin to parse the payload.
+`in_udp` uses the parser plugin to parse the payload.
 
 For more details:
 


### PR DESCRIPTION
This merge request fixes the inaccuracy in the UDP input parse section (fixes #408).