### PR TITLE
Fix a broken internal link

### DIFF
--- a/configuration/config-file.md
+++ b/configuration/config-file.md
@@ -507,7 +507,7 @@ These parameters are reserved and are prefixed with an `@` symbol:
 
 * `@label`: specifies the label symbol. See
 
-  [label](config-file.md#5-group-filter-and-output-the-ldquolabelrdquo-directive)
+  [label](config-file.md#5-group-filter-and-output-the-label-directive)
 
   section.
 


### PR DESCRIPTION
This `label` link doesn't work. So I fix it.
