### PR TITLE
Fix a broken internal link

### DIFF
--- a/configuration/config-file.md
+++ b/configuration/config-file.md
@@ -507,7 +507,7 @@ These parameters are reserved and are prefixed with an `@` symbol:
 
 * `@label`: specifies the label symbol. See
 
-  [label](config-file.md#5-group-filter-and-output-the-label-directive)
+  [label](config-file.md#5.-group-filter-and-output-the-label-directive)
 
   section.
 


### PR DESCRIPTION
I'm sorry. The fix of https://github.com/fluent/fluentd-docs-gitbook/pull/410 is inadequate.

The `label` link in https://docs.fluentd.org/configuration/config-file#common-plugin-parameters isn't still working after all.

Somehow it worked in my local environment, but it doesn't work on the production environment.
It is because `.` is not removed from DOM-id on the production environment.
