### PR TITLE
Document the new system option 'enable_jit'

### DIFF
--- a/deployment/system-config.md
+++ b/deployment/system-config.md
@@ -164,6 +164,14 @@ Parses config values strictly. Invalid numerical or boolean values are not allow
 
 Force disable the shared socket which is for listening a same port across multiple worker processes. When the shared socket is enabled \(it's the default behavior\), a socket is always created to enable workers to communicate with the supervisor. On Windows, it consumes a dynamic \(a.k.a ephemeral\) TCP port. If you don't prefer it, set this option as `true`. When it's disabled, you may not use plugins that listen a port such as in\_forward, in\_http and in\_syslog.
 
+### `enable_jit` (experimental)
+
+| type | default | version |
+| :--- | :--- | :--- |
+| bool | false | 1.15.1 |
+
+Enable JIT for worker processes. Internally, this configuration enables Ruby's `--jit` command-line option.
+
 ### `<log>` section
 
 #### `format`


### PR DESCRIPTION
This documents the new configuration option to enable Ruby's JIT.