### PR TITLE
Fix the name of license

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -54,5 +54,5 @@ The following articles will provide detailed information about Fluentd:
 * [High Availability Configuration](../deployment/high-availability.md)
 * [FAQ](faq.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under [the Apache License 2.0.](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/quickstart/faq.md
+++ b/quickstart/faq.md
@@ -115,5 +115,5 @@ If you are willing to write Regexp, [fluentd-ui's `in_tail` editor](../deploymen
 
 If you do NOT want to write any Regexp, look at [the Grok parser](https://github.com/kiyoto/fluent-plugin-grok-parser).
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under [the Apache License 2.0.](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/quickstart/life-of-a-fluentd-event.md
+++ b/quickstart/life-of-a-fluentd-event.md
@@ -232,5 +232,5 @@ Once the events are reported by the [Fluentd](http://fluend.org) engine on the *
 * [Fluentd v0.14 Blog Announcement](http://www.fluentd.org/blog/fluentd-v0.14.0-has-been-released)
 * [Fluentd v1.0 Blog Announcement](http://www.fluentd.org/blog/fluentd-v1.0)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under [the Apache License 2.0.](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/quickstart/logo.md
+++ b/quickstart/logo.md
@@ -25,5 +25,5 @@ Feel free to use these logos on your slides, blog posts, etc.
 * [Fluentd.ai](https://github.com/fluent/fluentd-docs-gitbook/tree/53020426cdcfcb5a5f722031838ee1cb95b5a7a2/images/logo/Fluentd.ai)
 * [Complete List of Logos](https://github.com/fluent/fluentd-docs-gitbook/tree/1.0/images/logo)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under [the Apache License 2.0.](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/quickstart/support.md
+++ b/quickstart/support.md
@@ -43,5 +43,5 @@ The source code is available at GitHub:
 
 * [Fluentd](https://github.com/fluent/fluentd/)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under [the Apache License 2.0.](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/quickstart/td-agent-v2-vs-v3-vs-v4.md
+++ b/quickstart/td-agent-v2-vs-v3-vs-v4.md
@@ -55,5 +55,5 @@ This is for v0.12 and old distribution users. We don't recommend this version fo
 * [macOS](../installation/install-by-dmg.md)
 * [RubyGems](../installation/install-by-gem.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under under [the Apache License 2.0.](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/quickstart/td-agent-v2-vs-v3-vs-v4.md
+++ b/quickstart/td-agent-v2-vs-v3-vs-v4.md
@@ -2,7 +2,7 @@
 
 ## Supported Platforms
 
-[Treasure Data, Inc.](https://www.treasuredata.com) maintains stable packages for Fluentd and canonical plugins as Treasure Agent \(the package is called `td-agent`\). `td-agent` has v2, v3 and v4. [Calyptia, Inc.](https://calyptia.com/) maintains stable packages as Calyptia-fluentd as another option. Supported OS is the same as td-agent v4 currently.
+[ClearCode, Inc.](https://www.clear-code.com) maintains stable packages for Fluentd and canonical plugins as Treasure Agent \(the package is called `td-agent`\). `td-agent` has v2, v3 and v4. [Calyptia, Inc.](https://calyptia.com/) maintains stable packages as Calyptia-fluentd as another option. Supported OS is the same as td-agent v4 currently.
 
 | Platform | v2 | v3 | v4\(x86\_64\) | v4\(Arm64\) |
 | :--- | :---: | :---: | :---: | :---: |


### PR DESCRIPTION
Footer in documents includes a wrong license information.
I have fixed the name into standard and added the link to the page for pages in quick start section to start with.