### PR TITLE
Remove a wrong description about overflow_action of out_forward

### DIFF
--- a/output/README.md
+++ b/output/README.md
@@ -163,7 +163,7 @@ Supported modes:
 
 * `throw_exception` \(default\)
 
-  This mode throws the`BufferOverflowError` exception to the input plugin. How `BufferOverflowError` is handled depends on the input plugins, e.g. tail input stops reading new lines, forward input returns an error to forward output. This action is suitable for streaming.
+  This mode throws the`BufferOverflowError` exception to the input plugin. How `BufferOverflowError` is handled depends on the input plugins, e.g. tail input stops reading new lines. This action is suitable for streaming.
 
 * `block`
 


### PR DESCRIPTION
out_forward never send error to client. It just doesn't send ack
response on error.
See also: https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1#response

Fix https://github.com/fluent/fluentd/issues/3742