### PR TITLE
Fix docs about log rotation

### DIFF
--- a/deployment/logging.md
+++ b/deployment/logging.md
@@ -156,7 +156,25 @@ $ fluentd -o /path/to/log_file
 
 ### Log Rotation Setting
 
-By default, Fluentd does not rotate log files. You can configure this behavior via command-line options:
+By default, Fluentd does not rotate log files. You can configure this behavior via system-config after v1.13.0.
+
+It can be configured through `<log>` directive under `<system>`:
+
+```text
+<system>
+  <log>
+    rotate_age 5
+    rotate_size 1048576
+  </log>
+</system>
+```
+
+You need to specify [`rotate_age`](system-config.md#rotate_age) or [`rotate_size`](system-config.md#rotate_size) options explicitly to enable log rotation.
+
+NOTE: You can omit one of these 2 options to use the default value, but if you omit both of them, log rotation is disabled.
+Actually, an external library manages these default values, resulting in this complication.
+
+You can use command-line options too (mainly for before v1.13.0):
 
 #### `--log-rotate-age AGE`
 

--- a/deployment/system-config.md
+++ b/deployment/system-config.md
@@ -198,6 +198,12 @@ Specifies time format.
 
 Specifies `daily`, `weekly`, `monthly` or integer which indicates age of log rotation.
 
+By default, Fluentd does not rotate log files. You need to specify `rotate_age` or `rotate_size` options explicitly to enable log rotation.
+
+NOTE: When enabling log rotation on Windows, log files are separated into `log-supervisor-0.log`, `log-0.log`, ..., `log-N.log` where `N` is `generation - 1` due to the system limitation. Windows does not permit delete and rename files simultaneously owned by another process.
+
+Please see also [Log Rotation Setting](logging.md#Log-Rotation-Setting).
+
 #### `rotate_size`
 
 | type | default | version |
@@ -205,6 +211,12 @@ Specifies `daily`, `weekly`, `monthly` or integer which indicates age of log rot
 | size | 1048576 | 1.13.0 |
 
 Specifies log file size limitation.
+
+By default, Fluentd does not rotate log files. You need to specify `rotate_age` or `rotate_size` options explicitly to enable log rotation.
+
+NOTE: When enabling log rotation on Windows, log files are separated into `log-supervisor-0.log`, `log-0.log`, ..., `log-N.log` where `N` is `generation - 1` due to the system limitation. Windows does not permit delete and rename files simultaneously owned by another process.
+
+Please see also [Log Rotation Setting](logging.md#Log-Rotation-Setting).
 
 #### `enable_input_metrics`
 


### PR DESCRIPTION
I would like to add 2 points about log ratation with this fix.

* Reflect in `deployment/logging.md` that we can set log rotation options with `system-config` after v1.13.0.
* Although those 2 options have a default value, we need to specify at least one of those options explicitly to enable log rotation.

At first, I thought the default values were wrong, but those default values are managed on ServerEngine side. 

* `rotate_age`
  * https://docs.fluentd.org/deployment/system-config#rotate_age
  * https://github.com/fluent/fluentd/blob/v1.15.2/lib/fluent/system_config.rb#L63
* `rotate_size`
  * https://docs.fluentd.org/deployment/system-config#rotate_size
  * https://github.com/fluent/fluentd/blob/v1.15.2/lib/fluent/system_config.rb#L76

In addition, we need to specify at least one of those options explicitly.

* https://github.com/fluent/fluentd/blob/v1.15.2/lib/fluent/supervisor.rb#L543-L549

This is complicated and hard to understand, so I think we need a document like this.
