### PR TITLE
Another failure reason for unknown placeholder

### DIFF
--- a/filter/record_transformer.md
+++ b/filter/record_transformer.md
@@ -296,7 +296,7 @@ ${record.dig("top", "nest1", "nest2")}
 
 ### I got `unknown placeholder ${record['msg']} found` error, why?
 
-Without `enable_ruby`, `${}` placeholder supports only double-quoted string for record field access. So, use `${record["key"]}` instead of `${record['key']}`.
+Without `enable_ruby`, `${}` placeholder supports only double-quoted string for record field access. So, use `${record["key"]}` instead of `${record['key']}`. This could also happen when the input does not contain `key`.
 
 ## Learn More
 


### PR DESCRIPTION
I think missing `key` in the input record is another reason for unknown placeholder error after reading https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/filter_record_transformer.rb, because when that happens we don't "prepare" it.