### PR TITLE
system: fix version of "enable_jit" option

### DIFF
--- a/deployment/system-config.md
+++ b/deployment/system-config.md
@@ -168,7 +168,7 @@ Force disable the shared socket which is for listening a same port across multip
 
 | type | default | version |
 | :--- | :--- | :--- |
-| bool | false | 1.15.1 |
+| bool | false | 1.15.2 |
 
 Enable JIT for worker processes. Internally, this configuration enables Ruby's `--jit` command-line option.
 


### PR DESCRIPTION
It seems to be wrong since the beginning.

- https://github.com/fluent/fluentd/pull/3857
- https://github.com/fluent/fluentd-docs-gitbook/pull/422
