### PR TITLE
Fix default value of rotate_age

### DIFF
--- a/deployment/system-config.md
+++ b/deployment/system-config.md
@@ -194,7 +194,7 @@ Specifies time format.
 
 | type | default | version |
 | :--- | :--- | :--- |
-| enum or integer | 5 | 1.13.0 |
+| enum or integer | 7 | 1.13.0 |
 
 Specifies `daily`, `weekly`, `monthly` or integer which indicates age of log rotation.
 


### PR DESCRIPTION
It seems that the old value came from `ServerEngine`.

* https://github.com/treasure-data/serverengine/blob/v2.3.1/lib/serverengine/daemon_logger.rb#L33

However, actually, `ServerEngine` has nothing to do with the rotation, and this value `5` is not used at all.

Actually, `Logger::LogDevice` manages the rotation, and the default value is `7`.

* https://github.com/ruby/logger/blob/v1.5.3/lib/logger/log_device.rb#L20

In Fluentd code, the parameters of `Fluent::LogDeviceIO` decides the behavior of the rotation.

* https://github.com/fluent/fluentd/blob/v1.15.3/lib/fluent/supervisor.rb#L563

The parameters of `ServerEngine::DaemonLogger` is meaningless.

* https://github.com/fluent/fluentd/blob/v1.15.3/lib/fluent/supervisor.rb#L580-L582

# Reproduce

* Env
  * Ubuntu Focal
  * Ruby 3.2
  * Fluentd 1.15.3
* Config
  * default `rotate_size`
  ```xml
  <system>
    <log>
      rotate_size 500
    </log>
  </system>

  <source>
    @type sample
    tag test.hoge
    sample {"message": "hoge"}
  </source>

  <match test.**>
    @type stdout
  </match>
  ```
  * `rotate_size 5`
  ```xml
  <system>
    <log>
      rotate_size 500
      rotate_age 5
    </log>
  </system>

  <source>
    @type sample
    tag test.hoge
    sample {"message": "hoge"}
  </source>

  <match test.**>
    @type stdout
  </match>
  ```
* Result
  * default `rotate_size`: 7 files are created
  ```
  fluentd.log
  fluentd.log.0
  fluentd.log.1
  fluentd.log.2
  fluentd.log.3
  fluentd.log.4
  fluentd.log.5
  ```
  * `rotate_size 5`: 5 files are created
  ```
  fluentd.log
  fluentd.log.0
  fluentd.log.1
  fluentd.log.2
  fluentd.log.3
  ```

The last index of 7th file is `5`.
I think it was hard to notice this mistake because of this.
