### PR TITLE
in_syslog: added note about in_syslog with regexp parser limitation

### DIFF
--- a/input/syslog.md
+++ b/input/syslog.md
@@ -373,8 +373,9 @@ If only timestamp is different, configure `time_format` in `<parse>` may help.
 
 If other parts are different, the `syslog` parser cannot parse your message. To resolve the problem, there are several approaches:
 
-* Use `regex` parser or write your parser
-* Use `in_udp`/`in_tcp` with other parsers
+* Use `in_udp`/`in_tcp` with other parsers (recommended)
+* Use `regexp` parser or write your parser
+  * Note that `in_syslog` consumes the priority literal implicitly without `with_priority true` in parser configuration, so in parse side, it can't be extracted.
 
 ## Learn More
 


### PR DESCRIPTION
in_syslog consumes the priority information implicitly [1] if parser doesn't support "with_priority true", so parser
can't parse it.

If the following message (non rfc3164/rfc5424 compatible) is received,

<1> Feb 20 00:00:00 192.168.0.1 fluentd[11111]: [error] foobar

in_syslog consumes head of priority information, thus parser will be given the rest of body such as:

 Feb 20 00:00:00 192.168.0.1 fluentd[11111]: [error] foobar

Thus parser regex expression must not contain \A\<(?<pri>[0-9]{1,3})\>.

[1]
https://github.com/fluent/fluentd/blob/0a6d706a9cee5882d751b2cc6169696709df0134/lib/fluent/plugin/in_syslog.rb#L228-L239