### PR TITLE
modify the mismatch of @label argument

### DIFF
--- a/configuration/plugin-common-parameters.md
+++ b/configuration/plugin-common-parameters.md
@@ -76,7 +76,7 @@ The `@label` parameter is to route the input events to `<label>` sections, the s
   # ...
 </source>
 
-<label @access_log>
+<label @access_logs>
   <match **>
     @type file
     path ...


### PR DESCRIPTION
Hello ! 

Hello, I found one mismatch argument in the example of the config file for `@label`.

The value of the parameter `@label` in the <source> section is `@access_logs`.
But the argument of `<label>` section is `@access_log`.

So I think we should change `<label @access_log>` to `<label @access_logs>`.

Please check the issue #454 .

Thank you.