### PR TITLE
fix typo: ignore_if_prev_success

### DIFF
--- a/output/copy.md
+++ b/output/copy.md
@@ -149,9 +149,9 @@ If plugin1's emit/format raises an error, plugin2 is not executed. If you want t
 </match>
 ```
 
-### `ignore_if_prev_successes` argument
+### `ignore_if_prev_success` argument
 
-Since Fluentd v1.12.2, you can use `ignore_if_prev_successes` to define fallback outputs. For example:
+Since Fluentd v1.12.2, you can use `ignore_if_prev_success` to define fallback outputs. For example:
 
 ```text
 <match app.**>


### PR DESCRIPTION
The `ignore_if_prev_success` argument is written as a plural noun in the [docs](https://docs.fluentd.org/output/copy#ignore_if_prev_successes-argument).

Based on fluentd's current v1.16.2 branch, `ignore_if_prev_success`, not `ignore_if_prev_successes`, is the argument that operates:

https://github.com/fluent/fluentd/blob/d5685ada81ac89a35a79965f1e94bbe5952a5d3a/lib/fluent/plugin/out_copy.rb#L43-L47

Therefore, I suggest fixing docs to reduce confusion.
