### PR TITLE
output/forward: add notification about specific use case

### DIFF
--- a/output/forward.md
+++ b/output/forward.md
@@ -333,6 +333,11 @@ Allows self-signed certificates or not.
 
 Verifies hostname of servers and certificates or not in TLS transport.
 
+If the following conditions are met, you must set `tls_verify_hostname false` explicitly to forward events correctly:
+
+* specify `host` in `<server>` section with IP address, not hostname
+* specify server certificate file with `tls_cert_path` which contains common name (CN) field with IP address, not hostname
+
 ### `tls_cert_path`
 
 | type | default | version |


### PR DESCRIPTION
Use case:

```
   tls_cert_path /etc/fluent/cert/fluentd.crt
   <server>
     host 192.168.10.100
     port 24224
   </server>
```

If CN in fluentd.crt is 192.168.10.100 (IP address), internally the value of hostname is nil, so #verify_hostname raise undefined method ascii_only? exception. To avoid exception, we must suppress verification with tls_veriry_hostname false.

See https://github.com/fluent/fluentd/discussions/4289