### PR TITLE
fix: :bug: `force_path_style` is deprecated

### DIFF
--- a/how-to-guides/apache-to-minio.md
+++ b/how-to-guides/apache-to-minio.md
@@ -49,7 +49,6 @@ Now let's add settings for storing the incoming data in your Minio server. Since
   s3_endpoint ENDPOINT          # The endpoint URL (like "http://localhost:9000/")
   s3_region us-east-1           # See the region settings of your Minio server
   path logs/                    # This prefix is added to each file
-  force_path_style true         # This prevents AWS SDK from breaking endpoint URL
   time_slice_format %Y%m%d%H%M  # This timestamp is added to each file name
 
   <buffer time>


### PR DESCRIPTION
This option is deprecated and it show up while I was restarting fluentd service [warn]: #0 'force_path_style' parameter is deprecated: S3 will drop path style API in 2020: See https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/

Signed-off-by: mehdiMj <mehdi.is@live.com>