### PR TITLE
Remove warning about issue that was closed years ago

### DIFF
--- a/input/tail.md
+++ b/input/tail.md
@@ -269,9 +269,10 @@ pos_file /var/log/td-agent/tmp/access.log.pos
 
 Don't share `pos_file` between `in_tail` configurations. It causes unexpected behavior e.g. corrupt `pos_file` content.
 
-`in_tail` removes the untracked file position at startup. It means that the content of `pos_file` keeps growing until a restart when you tails lots of files with the dynamic path setting.
-
-This [issue](https://github.com/fluent/fluentd/issues/1126) will be fixed in future.
+`in_tail` removes the untracked file position at startup.
+It means that the content of `pos_file` keeps growing until a restart when you tail
+lots of files with the dynamic path setting.
+This issue can be solved by using `pos_file_compaction_interval`.
 
 ### `pos_file_compaction_interval`
 


### PR DESCRIPTION
The current documentation at https://docs.fluentd.org/input/tail#pos_file-highly-recommended says 

> in_tail removes the untracked file position at startup. It means that the content of pos_file keeps growing until a restart when you tails lots of files with the dynamic path setting.
> This [issue](https://github.com/fluent/fluentd/issues/1126) will be fixed in future.


but that issue was closed 2020-02-30. 

So I think the documentation should remove the reference to that closed issue or alternatively it could be replaced with 

> `in_tail` removes the untracked file position at startup. It means that the content of `pos_file` keeps growing until a restart when you tails lots of files with the dynamic path setting. **This issue can be solved by using `pos_file_compaction_interval`**


