### PR TITLE
Enable hints plugin by default

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,7 +1,8 @@
 {
 	"title": "Fluentd 1.0 Documentation",
 	"plugins": [
-		"addcssjs"
+		"addcssjs",
+		"hints"
 	],
 
 	"pluginsConfig": {


### PR DESCRIPTION
It aims to markup emphasized topics (info,tip,danger,working).

See https://www.npmjs.com/package/gitbook-plugin-hints