### PR TITLE
Markup copy&paste friendly

### DIFF
--- a/installation/install-by-deb-td-agent-v4.md
+++ b/installation/install-by-deb-td-agent-v4.md
@@ -32,45 +32,51 @@ NOTE: Treasure Data does not verify Debian packages. If you have any problem wit
 
 A shell script is provided to automate the installation process for each version. The shell script registers a new apt repository at `/etc/apt/sources.list.d/treasure-data.list` and installs the `td-agent` deb package.
 
-For Ubuntu Jammy:
+#### For Ubuntu Jammy:
+
+##### td-agent 4 (experimental)
 
 ```bash
-# td-agent 4 (experimental)
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-ubuntu-jammy-td-agent4.sh | sh
 ```
 
-For Ubuntu Focal:
+#### For Ubuntu Focal:
+
+##### td-agent 4 (EOL)
 
 ```bash
-# td-agent 4
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-ubuntu-focal-td-agent4.sh | sh
 ```
 
-For Ubuntu Bionic:
+#### For Ubuntu Bionic:
+
+##### td-agent 4 (EOL)
 
 ```bash
-# td-agent 4
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-ubuntu-bionic-td-agent4.sh | sh
 ```
 
-For Ubuntu Xenial:
+#### For Ubuntu Xenial:
+
+##### td-agent 4 (EOL)
 
 ```bash
-# td-agent 4
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-ubuntu-xenial-td-agent4.sh | sh
 ```
 
-For Debian Bullseye:
+#### For Debian Bullseye:
+
+##### td-agent 4 (EOL)
 
 ```bash
-# td-agent 4
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-debian-bullseye-td-agent4.sh | sh
 ```
 
-For Debian Buster:
+#### For Debian Buster:
+
+##### td-agent 4 (EOL)
 
 ```bash
-# td-agent 4
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-debian-buster-td-agent4.sh | sh
 ```
 

--- a/installation/install-by-deb.md
+++ b/installation/install-by-deb.md
@@ -37,51 +37,59 @@ NOTE: If your OS is not supported, consider [gem installation](install-by-gem.md
 
 A shell script is provided to automate the installation process for each version. The shell script registers a new apt repository at `/etc/apt/sources.list.d/fluent.sources` (or `/etc/apt/sources.list.d/fluent-lts.sources`) and installs the `fluent-package` deb package.
 
-For Ubuntu Jammy:
+#### For Ubuntu Jammy:
+
+##### fluent-package 5 (LTS)
 
 ```bash
-# fluent-package 5 (LTS)
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-ubuntu-jammy-fluent-package5-lts.sh | sh
 ```
 
+##### fluent-package 5
+
 ```bash
-# fluent-package 5
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-ubuntu-jammy-fluent-package5.sh | sh
 ```
 
-For Ubuntu Focal:
+#### For Ubuntu Focal:
+
+##### fluent-package 5 (LTS)
 
 ```bash
-# fluent-package 5 (LTS)
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-ubuntu-focal-fluent-package5-lts.sh | sh
 ```
 
+##### fluent-package 5
+
 ```bash
-# fluent-package 5
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-ubuntu-focal-fluent-package5.sh | sh
 ```
 
-For Debian Bookworm:
+#### For Debian Bookworm:
+
+##### fluent-package 5 (LTS)
 
 ```bash
-# fluent-package 5 (LTS)
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-debian-bookworm-fluent-package5-lts.sh | sh
 ```
 
+##### fluent-package 5
+
 ```bash
-# fluent-package 5
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-debian-bookworm-fluent-package5.sh | sh
 ```
 
-For Debian Bullseye:
+#### For Debian Bullseye:
+
+##### fluent-package 5 (LTS)
 
 ```bash
-# fluent-package 5 (LTS)
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-debian-bullseye-fluent-package5-lts.sh | sh
 ```
 
+##### fluent-package 5
+
 ```bash
-# fluent-package 5
 curl -fsSL https://toolbelt.treasuredata.com/sh/install-debian-bullseye-fluent-package5.sh | sh
 ```
 

--- a/installation/install-by-rpm-td-agent-v4.md
+++ b/installation/install-by-rpm-td-agent-v4.md
@@ -34,9 +34,10 @@ NOTE: If your OS is not supported, consider [gem installation](install-by-gem.md
 
 Download and execute the install script with `curl`:
 
-```text
-# td-agent 4
-$ curl -L https://toolbelt.treasuredata.com/sh/install-redhat-td-agent4.sh | sh
+##### td-agent 4 (EOL)
+
+```bash
+curl -L https://toolbelt.treasuredata.com/sh/install-redhat-td-agent4.sh | sh
 ```
 
 Executing this script will automatically install `td-agent` on your machine. This shell script registers a new `rpm` repository at `/etc/yum.repos.d/td.repo` and installs `td-agent`.
@@ -47,9 +48,10 @@ We use `$releasever` for repository path in the script and `$releasever` should 
 
 For Amazon Linux 2:
 
-```text
-# td-agent 4
-$ curl -L https://toolbelt.treasuredata.com/sh/install-amazon2-td-agent4.sh | sh
+##### td-agent 4 (EOL)
+
+```bash
+curl -L https://toolbelt.treasuredata.com/sh/install-amazon2-td-agent4.sh | sh
 ```
 
 ### Step 2: Launch Daemon

--- a/installation/install-by-rpm.md
+++ b/installation/install-by-rpm.md
@@ -41,14 +41,16 @@ NOTE: If your OS is not supported, consider [gem installation](install-by-gem.md
 
 Download and execute the install script with `curl`:
 
-```text
-# fluent-package 5 (LTS)
-$ curl -fsSL https://toolbelt.treasuredata.com/sh/install-redhat-fluent-package5-lts.sh | sh
+##### fluent-package 5 (LTS)
+
+```bash
+curl -fsSL https://toolbelt.treasuredata.com/sh/install-redhat-fluent-package5-lts.sh | sh
 ```
 
-```text
-# fluent-package 5
-$ curl -fsSL https://toolbelt.treasuredata.com/sh/install-redhat-fluent-package5.sh | sh
+##### fluent-package 5
+
+```bash
+curl -fsSL https://toolbelt.treasuredata.com/sh/install-redhat-fluent-package5.sh | sh
 ```
 
 Executing this script will automatically install `fluent-package` on your machine. This shell script registers a new `rpm` repository at `/etc/yum.repos.d/fluent-package.repo` (or `/etc/yum.repos.d/fluent-package-lts.repo`) and installs `fluent-package`.
@@ -57,28 +59,32 @@ We use `$releasever` for repository path in the script and `$releasever` should 
 
 #### Amazon Linux
 
-For Amazon Linux 2023:
+##### For Amazon Linux 2023:
 
-```text
-# fluent-package 5 (LTS)
-$ curl -fsSL https://toolbelt.treasuredata.com/sh/install-amazon2023-fluent-package5-lts.sh | sh
+###### fluent-package 5 (LTS)
+
+```bash
+curl -fsSL https://toolbelt.treasuredata.com/sh/install-amazon2023-fluent-package5-lts.sh | sh
 ```
 
-```text
-# fluent-package 5
-$ curl -fsSL https://toolbelt.treasuredata.com/sh/install-amazon2023-fluent-package5.sh | sh
+###### fluent-package 5
+
+```bash
+curl -fsSL https://toolbelt.treasuredata.com/sh/install-amazon2023-fluent-package5.sh | sh
 ```
 
-For Amazon Linux 2:
+##### For Amazon Linux 2:
 
-```text
-# fluent-package 5 (LTS)
-$ curl -fsSL https://toolbelt.treasuredata.com/sh/install-amazon2-fluent-package5-lts.sh | sh
+###### fluent-package 5 (LTS)
+
+```bash
+curl -fsSL https://toolbelt.treasuredata.com/sh/install-amazon2-fluent-package5-lts.sh | sh
 ```
 
-```text
-# fluent-package 5
-$ curl -fsSL https://toolbelt.treasuredata.com/sh/install-amazon2-fluent-package5.sh | sh
+###### fluent-package 5
+
+```bash
+curl -fsSL https://toolbelt.treasuredata.com/sh/install-amazon2-fluent-package5.sh | sh
 ```
 
 ### Step 2: Launch Daemon


### PR DESCRIPTION
* Use bash highlighting ($ is added by default)
* Eliminate "fluent-package 5" and "fluent-package 5 (LTS)" label from code blocks