### PR TITLE
issue #496 'Installation for MacOS need information'

### DIFF
--- a/installation/install-by-dmg.md
+++ b/installation/install-by-dmg.md
@@ -83,6 +83,10 @@ To uninstall `fluent-package` from macOS, remove these files / directories:
 
 ## `calyptia-fluentd` v1
 
+### Prerequisite: Install ruby 3.x
+
+Install ruby version 3.x using brew and update the path variable.
+
 ### Step 1: Install `calyptia-fluentd`
 
 Download and install the `.dmg` package:


### PR DESCRIPTION
Adding the required prerequisite step to calyptia-fluentd instruction.