### PR TITLE
guides webhdfs: fix `Unknown language: "markup"` error

### DIFF
--- a/how-to-guides/http-to-hdfs.md
+++ b/how-to-guides/http-to-hdfs.md
@@ -77,7 +77,7 @@ Other options specify HDFS's NameNode host and port.
 
 Append operations are not enabled by default. Please put these configurations into your `hdfs-site.xml` file and restart the whole cluster:
 
-```markup
+```text
 <property>
   <name>dfs.webhdfs.enabled</name>
   <value>true</value>


### PR DESCRIPTION
When I built the documents using HonKit, I met the following error message:

```
$ npx honkit build
(node:128004) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
info: 7 plugins are installed
info: 7 explicitly listed
info: plugin "addcssjs" is loaded
info: plugin "hints" is loaded
info: plugin "highlight" is loaded
info: plugin "search" is loaded
info: plugin "lunr" is loaded
info: plugin "fontsettings" is loaded
info: plugin "theme-default" is loaded
info: found 191 pages
info: found 237 asset files
warn: "this.generator" property is deprecated, use "this.output.name" instead
warn: "navigation" property is deprecated
warn: "book" property is deprecated, use "this" directly instead
warn: "options" property is deprecated, use config.get(key) instead
Could not find the language 'markup', did you forget to load/include a language module?
Error: Unknown language: "markup"
    at _highlight (/home/watson/src/fluentd-docs-gitbook/node_modules/highlight.js/lib/core.js:2107:13)
    at Object.highlight (/home/watson/src/fluentd-docs-gitbook/node_modules/highlight.js/lib/core.js:1720:9)
    at highlight (/home/watson/src/fluentd-docs-gitbook/node_modules/@honkit/honkit-plugin-highlight/index.js:36:21)
    at Object.code (/home/watson/src/fluentd-docs-gitbook/node_modules/@honkit/honkit-plugin-highlight/index.js:60:20)
    at TemplateBlock.applyBlock (/home/watson/src/fluentd-docs-gitbook/node_modules/honkit/lib/models/templateBlock.js:163:29)
    at /home/watson/src/fluentd-docs-gitbook/node_modules/honkit/lib/output/getModifiers.js:47:48
    at /home/watson/src/fluentd-docs-gitbook/node_modules/honkit/lib/output/modifiers/highlightCode.js:49:39
    at /home/watson/src/fluentd-docs-gitbook/node_modules/honkit/lib/output/modifiers/editHTMLElement.js:14:16
    at /home/watson/src/fluentd-docs-gitbook/node_modules/honkit/lib/utils/promise.js:40:16
    at /home/watson/src/fluentd-docs-gitbook/node_modules/honkit/lib/utils/promise.js:25:20
info: >> generation finished with success in 19.8s !
```

Seem that an error occurred by specified unknown `markup`.
So this patch will fix this error.