### PR TITLE
faq: update supported Ruby version

### DIFF
--- a/quickstart/faq.md
+++ b/quickstart/faq.md
@@ -2,9 +2,9 @@
 
 ## Which version of Ruby does `fluentd` support?
 
-Latest fluentd works on Ruby 2.5 or later.
+Latest fluentd works on Ruby 2.7 or later.
 
-Though the minimum required version is Ruby 2.5 or later, we recommend using `fluentd` with more
+Though the minimum required version is Ruby 2.7 or later, we recommend using `fluentd` with more
 newer stable version.
 
 ## What is the difference between v1 or v0.14?


### PR DESCRIPTION
According to https://github.com/fluent/fluentd/blob/5618dd0e86bf0bc47a6bed2da50e37943ac2c8e9/fluentd.gemspec#L23,
Fluentd has supported Ruby 2.7 or later.