### PR TITLE
in_syslog: add receive_buffer_size parameter

### DIFF
--- a/configuration/transport-section.md
+++ b/configuration/transport-section.md
@@ -62,6 +62,20 @@ On Windows, Fluentd sends FIN without depending on this setting.
 </transport>
 ```
 
+#### `receive_buffer_size`
+
+| type | default | available transport type | version |
+| :--- | :--- | :--- | :--- |
+| integer | nil | tcp, udp, tls | 1.18.0 |
+
+The max size of socket receive buffer for TCP/UDP. This is used in `SO_RCVBUF` socket option.
+
+```text
+<transport udp>
+  receive_buffer_size 4194304
+</transport>
+```
+
 ### TLS Setting
 
 * `version`: \[enum: `TLS1_1`/`TLS1_2`/`TLS1_3`\]

--- a/input/syslog.md
+++ b/input/syslog.md
@@ -103,7 +103,8 @@ The protocol of the `syslog` transport.
 </source>
 ```
 
-See **How to Enable TLS Encryption** section for how to use and see [Configuration Example](../plugin-helper-overview/api-plugin-helper-server.md#configuration-example) for all supported parameters.
+This section is for setting TLS transport or some general transport configurations.
+See **How to Enable TLS Encryption** section for how to use and see [Configuration Example](../plugin-helper-overview/api-plugin-helper-server.md#configuration-example) and [Config: Transport Section](../configuration/transport-section.md) for all supported parameters.
 
 ### `message_length_limit`
 

--- a/input/tcp.md
+++ b/input/tcp.md
@@ -148,6 +148,7 @@ The maximum number of bytes for the message.
 | enum | tcp | tcp, tls | 0.14.12 |
 
 This section is for setting TLS transport or some general transport configurations.
+See [Config: Transport Section](../configuration/transport-section.md) for all supported parameters.
 
 #### General configuration
 

--- a/input/udp.md
+++ b/input/udp.md
@@ -141,7 +141,18 @@ Removes the newline from the end of the incoming payload.
 | :--- | :--- | :--- |
 | size | nil | 1.0.1 |
 
+This is a deprecated parameter. Use `receive_buffer_size` in `<transport>` section instead.
+
 The max size of socket receive buffer. This is used in `SO_RCVBUF` socket option.
+
+### `<transport>` Section
+
+| type | default | available values | version |
+| :--- | :--- | :--- | :--- |
+| enum | udp | udp | 1.18.0 |
+
+This section is for some general transport configurations.
+See [Config: Transport Section](../configuration/transport-section.md) for all supported parameters.
 
 ### `<parse>` Section
 


### PR DESCRIPTION
This will add a description of `receive_buffer_size` parameter in in_syslog plugin

Related to https://github.com/fluent/fluentd/pull/4649