### PR TITLE
transport section: add missing description for 'linger_timeout'

### DIFF
--- a/configuration/transport-section.md
+++ b/configuration/transport-section.md
@@ -26,8 +26,41 @@ The **`transport`** section must be under `<match>`, `<source>`, and `<filter>` 
 
 ## Parameters
 
-* `protocol` \[enum: `tcp`/`udp`/`tls`\]
+### Protocol
+
+The protocol is specified as the argument of `<transport>` section.
+
+```
+<transport PROTOCOL>
+</transport>
+```
+
+* \[enum: `tcp`/`udp`/`tls`\]
   * Default: `tcp`
+
+### General Setting
+
+#### `linger_timeout`
+
+| type | default | available transport type | version |
+| :--- | :--- | :--- | :--- |
+| integer | 0 | tcp, tls | 1.14.6 |
+
+The timeout \(seconds\) to set `SO_LINGER`.
+
+The default value `0` is to send RST rather than FIN to avoid lots of connections sitting in TIME_WAIT on closing.
+
+You can set positive value to send FIN on closing.
+
+{% hint style='info' %}
+On Windows, Fluentd sends FIN without depending on this setting.
+{% endhint %}
+
+```
+<transport tcp>
+  linger_timeout 1
+</transport>
+```
 
 ### TLS Setting
 

--- a/input/forward.md
+++ b/input/forward.md
@@ -174,7 +174,9 @@ The default value `0` is to send RST rather than FIN to avoid lots of connection
 
 You can set positive value to send FIN on closing on non-Windows.
 
-(On Windows, Fluentd sends FIN when `linger_timeout` is `0` too).
+{% hint style='info' %}
+On Windows, Fluentd sends FIN without depending on this setting.
+{% endhint %}
 
 ```text
 <transport tcp>

--- a/input/http.md
+++ b/input/http.md
@@ -217,7 +217,9 @@ The default value `0` is to send RST rather than FIN to avoid lots of connection
 
 You can set positive value to send FIN on closing on non-Windows.
 
-(On Windows, Fluentd sends FIN when `linger_timeout` is `0` too).
+{% hint style='info' %}
+On Windows, Fluentd sends FIN without depending on this setting.
+{% endhint %}
 
 ```text
 <transport tcp>

--- a/input/tcp.md
+++ b/input/tcp.md
@@ -163,7 +163,9 @@ The default value `0` is to send RST rather than FIN to avoid lots of connection
 
 You can set positive value to send FIN on closing on non-Windows.
 
-(On Windows, Fluentd sends FIN when `linger_timeout` is `0` too).
+{% hint style='info' %}
+On Windows, Fluentd sends FIN without depending on this setting.
+{% endhint %}
 
 ```text
 <source>

--- a/plugin-helper-overview/api-plugin-helper-server.md
+++ b/plugin-helper-overview/api-plugin-helper-server.md
@@ -174,7 +174,9 @@ The default value `0` is to send RST rather than FIN to avoid lots of connection
 
 You can set positive value to send FIN on closing on non-Windows.
 
-(On Windows, Fluentd sends FIN when `linger_timeout` is `0` too).
+{% hint style='info' %}
+On Windows, Fluentd sends FIN without depending on this setting.
+{% endhint %}
 
 ```text
 <source>


### PR DESCRIPTION
Add the missing description for `linger_timeout`, which is added in the following.

* https://github.com/fluent/fluentd/issues/3644
* https://github.com/fluent/fluentd-docs-gitbook/pull/392