### PR TITLE
Calyptia references removal

### DIFF
--- a/configuration/config-file.md
+++ b/configuration/config-file.md
@@ -167,9 +167,6 @@ Let's add standard `record_transformer` filter to `match` example.
 </match>
 ```
 
-Visualization of configuration: [https://link.calyptia.com/6mk](https://link.calyptia.com/6mk) \(sign-up required\)
-
-![Visualization from Calyptia](../.gitbook/assets/screen-shot-2021-03-16-at-12.57.45-pm.png)
 
 The received event `{"event":"data"}` goes to `record_transformer` filter first. The `record_transformer` filter adds `host_param` field to the event; and, then the filtered event `{"event":"data","host_param":"webserver1"}` goes to the `file` output plugin.
 
@@ -261,9 +258,6 @@ Here is a configuration example:
 </label>
 ```
 
-Visualization of configuration: [https://link.calyptia.com/dxn](https://link.calyptia.com/dxn) \(sign-up required\)
-
-![Visualization from Calyptia](../.gitbook/assets/screen-shot-2021-03-16-at-12.59.05-pm.png)
 
 In this configuration, `forward` events are routed to `record_transformer` filter / `elasticsearch` output and `in_tail` events are routed to `grep` filter / `s3` output inside `@SYSTEM` label.
 
@@ -587,9 +581,6 @@ The configuration file can be validated without starting the plugins using the `
 $ fluentd --dry-run -c fluent.conf
 ```
 
-## Config Validator
-
-You can use the Calyptia Cloud advisor for tips on Fluentd configuration. Sign up required at https://cloud.calyptia.com.
 
 ## Format Tips
 

--- a/deployment/fluentd-ui.md
+++ b/deployment/fluentd-ui.md
@@ -11,9 +11,8 @@
 
 ## Enterprise
 
-[Calyptia](https://www.calyptia.com), from [fluentd.org/enterprise](https://www.fluentd.org/enterprise), offers an enterprise UI on top of Fluentd and Fluent Bit. Please visit their site for more information
+[Chronosphere Telemetry Pipeline](https://chronosphere.io/platform/telemetry-pipeline/) provides an enterprise UI on top of Fluentd and Fluent Bit. Please visit their site for more information.
 
-![](../.gitbook/assets/image.png)
 
 ## Getting Started
 

--- a/installation/install-by-deb.md
+++ b/installation/install-by-deb.md
@@ -1,6 +1,6 @@
 # Install by DEB Package \(Debian/Ubuntu\)
 
-This article explains how to install stable versions of `fluent-package` deb packages, the stable Fluentd distribution packages maintained by [Fluentd Project](https://www.fluentd.org/) and `calyptia-fluentd` which is maintained by [Calyptia, Inc.](https://www.calyptia.com/).
+This article explains how to install stable versions of `fluent-package` deb packages, the stable Fluentd distribution packages maintained by [Fluentd Project](https://www.fluentd.org/) and `calyptia-fluentd` which is maintained by [Chronosphere](https://chronosphere.io) after its acquisition of Calyptia.
 
 ## What is `fluent-package`?
 
@@ -10,9 +10,9 @@ That is why [Fluentd Project](https://www.fluentd.org/) provides **the stable di
 
 ## What is `calyptia-fluentd`?
 
-Our Calyptia also knows that Fluentd is written in Ruby for flexibility, with performance-sensitive parts in C. However, some users may have difficulty installing and operating a Ruby daemon. And `td-agent` is still seated on Ruby 2.7 due to compatibility reasons and Ruby versioning policy, `calyptia-fluentd` uses Ruby 3 instead of Ruby 2.7 for now.
+Fluentd is written in Ruby for flexibility, with performance-sensitive parts in C. However, some users may have difficulty installing and operating a Ruby daemon. And `td-agent` is still seated on Ruby 2.7 due to compatibility reasons and Ruby versioning policy, `calyptia-fluentd` uses Ruby 3 instead of Ruby 2.7 for now.
 
-That is why [Calyptia, Inc.](https://www.calyptia.com/) provides **the alternative stable distribution of Fluentd**, called `calyptia-fluentd`. The differences between `td-agent` and `calyptia-fluentd` are bundled and running Ruby versions for now.
+That is why Chronosphere (formerly Calyptia) provides **the alternative stable distribution of Fluentd**, called `calyptia-fluentd`. The differences between `td-agent` and `calyptia-fluentd` are bundled and running Ruby versions for now.
 
 This installation guide is for `fluent-package` v5 and `calyptia-fluentd` v1. `fluent-package` v5 and `calyptia-fluentd` use fluentd v1 in the core. See [fluent-package-v5-vs-td-agent](../quickstart/fluent-package-v5-vs-td-agent.md) or [td-agent-v2-vs-v3-vs-v4](../quickstart/td-agent-v2-vs-v3-vs-v4.md) for the comparison and supported OS.
 

--- a/installation/install-by-dmg.md
+++ b/installation/install-by-dmg.md
@@ -1,6 +1,6 @@
 # Install by .dmg Package \(macOS\)
 
-This article explains how to install stable versions of `fluent-package` dmg packages, the stable Fluentd distribution packages maintained by [Fluentd Project](https://www.fluentd.org/) and `calyptia-fluentd` which is maintained by [Calyptia, Inc.](https://www.calyptia.com/) on macOS.
+This article explains how to install stable versions of `fluent-package` dmg packages, the stable Fluentd distribution packages maintained by [Fluentd Project](https://www.fluentd.org/) and `calyptia-fluentd` which is maintained by [Chronosphere](https://chronosphere.io) after its acquisition of Calyptia on macOS.
 
 ## What is `fluent-package`?
 
@@ -10,9 +10,9 @@ That is why [Fluentd Project](https://www.fluentd.org/) provides **the stable di
 
 ## What is `calyptia-fluentd`?
 
-Our Calyptia also knows that Fluentd is written in Ruby for flexibility, with performance-sensitive parts in C. However, some users may have difficulty installing and operating a Ruby daemon. And `td-agent` is still seated on Ruby 2.7 due to compatibility reasons and Ruby versioning policy, `calyptia-fluentd` uses Ruby 3 instead of Ruby 2.7 for now.
+Fluentd is written in Ruby for flexibility, with performance-sensitive parts in C. However, some users may have difficulty installing and operating a Ruby daemon. And `td-agent` is still seated on Ruby 2.7 due to compatibility reasons and Ruby versioning policy, `calyptia-fluentd` uses Ruby 3 instead of Ruby 2.7 for now.
 
-That is why [Calyptia, Inc.](https://www.calyptia.com/) provides **the alternative stable distribution of Fluentd**, called `calyptia-fluentd`. The differences between `td-agent` and `calyptia-fluentd` are bundled and running Ruby versions for now.
+That is why Chronosphere (formerly Calyptia) provides **the alternative stable distribution of Fluentd**, called `calyptia-fluentd`. The differences between `td-agent` and `calyptia-fluentd` are bundled and running Ruby versions for now.
 
 For macOS, `td-agent` is distributed as `.dmg` installer.
 

--- a/installation/install-by-msi.md
+++ b/installation/install-by-msi.md
@@ -20,7 +20,7 @@ Currently two versions of distributions are available.
 
 * Includes Ruby and other library dependencies \(since most Windows box are not installed\).
 * Includes a set of frequently-used 3rd party plugins such as `out_elasticsearch` and `in_windows_eventlog2`.
-* This alternative agent is developed by [Calyptia, Inc.](https://www.calyptia.com/).
+* This alternative agent is developed by [Chronosphere](https://chronosphere.io) after its acuisition of Calyptia.
 
 Currently, calyptia-fluentd is on v1 only.
 

--- a/installation/install-by-rpm.md
+++ b/installation/install-by-rpm.md
@@ -1,6 +1,6 @@
 # Install by RPM Package \(Red Hat Linux\)
 
-This article explains how to install stable versions of `fluent-package` rpm packages, the stable Fluentd distribution packages maintained by [Fluentd Project](https://www.fluentd.org/) and `calyptia-fluentd` which is maintained by [Calyptia, Inc.](https://www.calyptia.com/).
+This article explains how to install stable versions of `fluent-package` rpm packages, the stable Fluentd distribution packages maintained by [Fluentd Project](https://www.fluentd.org/) and `calyptia-fluentd` which is maintained by [Chronosphere](https://chronosphere.io) after its acquisition of Calyptia.
 
 ## What is `fluent-package`?
 
@@ -10,9 +10,9 @@ That is why [Fluentd Project](https://www.fluentd.org/) provides **the stable di
 
 ## What is `calyptia-fluentd`?
 
-Our Calyptia also knows that Fluentd is written in Ruby for flexibility, with performance-sensitive parts in C. However, some users may have difficulty installing and operating a Ruby daemon. And `td-agent` is still seated on Ruby 2.7 due to compatibility reasons and Ruby versioning policy, `calyptia-fluentd` uses Ruby 3 instead of Ruby 2.7 for now.
+Fluentd is written in Ruby for flexibility, with performance-sensitive parts in C. However, some users may have difficulty installing and operating a Ruby daemon. And `td-agent` is still seated on Ruby 2.7 due to compatibility reasons and Ruby versioning policy, `calyptia-fluentd` uses Ruby 3 instead of Ruby 2.7 for now.
 
-That is why [Calyptia, Inc.](https://www.calyptia.com/) provides **the alternative stable distribution of Fluentd**, called `calyptia-fluentd`. The differences between `td-agent` and `calyptia-fluentd` are bundled and running Ruby versions for now.
+That is why Chronosphere (formerly Calyptia) provides **the alternative stable distribution of Fluentd**, called `calyptia-fluentd`. The differences between `td-agent` and `calyptia-fluentd` are bundled and running Ruby versions for now.
 
 This installation guide is for `fluent-package` v5 and `calyptia-fluentd` v1. `fluent-package` v5 and `calyptia-fluentd` use fluentd v1 in the core. See [fluent-package-v5-vs-td-agent](../quickstart/fluent-package-v5-vs-td-agent.md) or [td-agent-v2-vs-v3-vs-v4](../quickstart/td-agent-v2-vs-v3-vs-v4.md) for the comparison and supported OS.
 

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -53,6 +53,6 @@ And this `local` type plugin should be used by default.
 
 NOTE: This 3rd party metrics plugin list does not fully covers all of them.
 
-* [fluent-plugin-metrics-cmetrics](https://github.com/calyptia/fluent-plugin-metrics-cmetrics)
+* [fluent-plugin-metrics-cmetrics](https://github.com/chronosphereio/calyptia-fluent-plugin-metrics-cmetrics)
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.

--- a/quickstart/life-of-a-fluentd-event.md
+++ b/quickstart/life-of-a-fluentd-event.md
@@ -118,9 +118,7 @@ A **Filter** behaves like a rule to pass or reject an event. The following confi
 </match>
 ```
 
-Fluentd configuration visualization link: [https://link.calyptia.com/gjl](https://link.calyptia.com/gjl) \(sign-up required\)
-
-![Visualization from Calyptia](../.gitbook/assets/screen-shot-2021-03-16-at-12.50.12-pm.png)
+![Visualization](../.gitbook/assets/screen-shot-2021-03-16-at-12.50.12-pm.png)
 
 As you can see, the new **Filter** definition will be a mandatory step to pass before the control goes to the **Match** section. The **Filter** basically will accept or reject the **Event** based on its `type` and rule. For our example we want to discard any user **logout** action. We only care about the **logins**. The way to accomplish this, is doing a `grep` inside the **Filter** to exclude any message on which `action` key have the **logout** string.
 
@@ -210,9 +208,7 @@ This new implementation called **Labels**, aims to solve the configuration file 
 </label>
 ```
 
-Fluentd configuration visualization: [https://link.calyptia.com/guh](https://link.calyptia.com/guh) \(sign-up required\)
-
-![Visualization from Calyptia](../.gitbook/assets/screen-shot-2021-03-16-at-12.51.26-pm.png)
+![Visualization](../.gitbook/assets/screen-shot-2021-03-16-at-12.51.26-pm.png)
 
 The new configuration contains a `@label` parameter under `source` indicating that the further steps will take place on the `@STAGING` label section. The expectation is that every event reported on the **Source**, the **Routing Engine** will continue processing on `@STAGING`. Hence, it will skip the old filter definition.
 

--- a/quickstart/td-agent-v2-vs-v3-vs-v4.md
+++ b/quickstart/td-agent-v2-vs-v3-vs-v4.md
@@ -2,7 +2,7 @@
 
 ## Supported Platforms
 
-[ClearCode, Inc.](https://www.clear-code.com) maintains stable packages for Fluentd and canonical plugins as Treasure Agent \(the package is called `td-agent`\). `td-agent` has v2, v3 and v4. [Calyptia, Inc.](https://calyptia.com/) maintains stable packages as Calyptia-fluentd as another option. Supported OS is the same as td-agent v4 currently.
+[ClearCode, Inc.](https://www.clear-code.com) maintains stable packages for Fluentd and canonical plugins as Treasure Agent \(the package is called `td-agent`\). `td-agent` has v2, v3 and v4. [Chronosphere](https://chronosphere.io/) (formerly Calyptia) maintains stable packages as Calyptia-fluentd as another option. Supported OS is the same as td-agent v4 currently.
 
 | Platform | v2 | v3 | v4\(x86\_64\) | v4\(Arm64\) |
 | :--- | :---: | :---: | :---: | :---: |


### PR DESCRIPTION
Swaps references to Calyptia the company to Chronosphere since Calyptia was acquired in 2024. 

Removes links to configuration visualization and validator tool since it is no longer part of the product. 