### PR TITLE
Update explanation of ChangeLog

### DIFF
--- a/quickstart/support.md
+++ b/quickstart/support.md
@@ -31,7 +31,13 @@ Here are other community resources:
 If you are interested in what's new in each version, please refer to the following links:
 
 * [Fluentd's ChangeLog](https://github.com/fluent/fluentd/blob/master/CHANGELOG.md).
-* [td-agent's ChangeLog](https://docs.treasuredata.com/display/public/PD/The+td-agent+Change+Log)
+* [fluent-package's ChangeLog](https://github.com/fluent/fluent-package-builder/blob/master/CHANGELOG.md) (Successor of td-agent package)
+* [td-agent's ChangeLog](https://github.com/fluent/fluent-package-builder/blob/master/CHANGELOG-v4.md) (End of Life in Dec, 2023)
+
+{% hint style='danger' %}
+The series of td-agent had already reached End of Life (EOL). td-agent should not be newly installed because no support, no new release and no security updates anymore.
+Use fluent-package instead. See [Upgrade to fluent-package v5](https://www.fluentd.org/blog/upgrade-td-agent-v4-to-v5) for migration.
+{% endhint %}
 
 ## Development
 


### PR DESCRIPTION
https://docs.treasuredata.com/display/public/PD/The+td-agent+Change+Log was redirected into
https://docs.treasuredata.com/articles/#!pd/The-td-agent-Change-Log, but that page was not found anymore.