### PR TITLE
Fix wording in hints about deprecated td-agent

### DIFF
--- a/installation/install-by-dmg-fluent-package.md
+++ b/installation/install-by-dmg-fluent-package.md
@@ -15,10 +15,14 @@ You can also see [fluent-package-v5-vs-td-agent](../quickstart/fluent-package-v5
 {% hint style='info' %}
 NOTE:
 
+* `fluent-package` is not be shipped yet, we plan to migrate to homebrew ecosystem in the future.
+{% endhint %}
+
+{% hint style='danger' %}
+The following are deprecated td-agent (EOL) information:
+
 * About Treasure Agent (td-agent) v4, see [Install by .dmg Package \(macOS\)](install-by-dmg-td-agent-v4.md).
 * About deprecated [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), see [Install by DEB Package  v3](install-by-deb-td-agent-v3.md).
-* `fluent-package` is not be shipped yet, we plan to migrate to homebrew ecosystem in the future.
-
 {% endhint %}
 
 <!-- Revise instructions when fluent-package with homebrew was released

--- a/installation/install-by-dmg-td-agent-v3.md
+++ b/installation/install-by-dmg-td-agent-v3.md
@@ -11,7 +11,9 @@ That is why [Treasure Data, Inc](http://www.treasuredata.com/) provides **the st
 ## `td-agent` v3
 
 {% hint style='danger' %}
-NOTE: As [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), recommend to [Upgrade td-agent from v3 to v4](https://www.fluentd.org/blog/upgrade-td-agent-v3-to-v4).
+This article contains deprecated td-agent (EOL) information: SHOULD NOT use td-agent anymore.
+
+* `fluent-package` (successor of `td-agent`) for macOS is not be shipped yet, we plan to migrate to homebrew ecosystem in the future.
 {% endhint %}
 
 ### Step 1: Install `td-agent`

--- a/installation/install-by-dmg-td-agent-v4.md
+++ b/installation/install-by-dmg-td-agent-v4.md
@@ -13,7 +13,9 @@ For macOS, `td-agent` is distributed as `.dmg` installer.
 ## Step 1: Install `td-agent`
 
 {% hint style='danger' %}
-NOTE: About deprecated [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), see [Install by .dmg Package \(macOS\)](install-by-dmg-td-agent-v3.md).
+This article contains deprecated td-agent (EOL) information: SHOULD NOT use td-agent anymore.
+
+* `fluent-package` (successor of `td-agent`) for macOS is not be shipped yet, we plan to migrate to homebrew ecosystem in the future.
 {% endhint %}
 
 Download and install the `.dmg` package:

--- a/installation/install-by-msi-fluent-package.md
+++ b/installation/install-by-msi-fluent-package.md
@@ -13,8 +13,8 @@ You can also see [fluent-package-v5-vs-td-agent](../quickstart/fluent-package-v5
 
 ## How to install `fluent-package`
 
-{% hint style='info' %}
-NOTE:
+{% hint style='danger' %}
+The following are deprecated td-agent (EOL) information:
 
 * About deprecated [Treasure Agent (td-agent) v4 (EOL)](https://www.fluentd.org/blog/schedule-for-td-agent-4-eol), see [Install by .msi Installer v4 (Windows)](install-by-msi-td-agent-v4.md).
 * About deprecated [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), see [Install by msi Package  v3](install-by-msi-td-agent-v3.md).

--- a/installation/install-by-msi-td-agent-v3.md
+++ b/installation/install-by-msi-td-agent-v3.md
@@ -18,7 +18,10 @@ Currently two versions of `td-agent` are available.
 ## `td-agent` v3
 
 {% hint style='danger' %}
-NOTE: As [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), recommend to [Upgrade td-agent from v3 to v4](https://www.fluentd.org/blog/upgrade-td-agent-v3-to-v4).
+This article contains deprecated td-agent (EOL) information: SHOULD NOT use td-agent anymore.
+
+* As [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), recommend to [Upgrade td-agent from v3 to v4](https://www.fluentd.org/blog/upgrade-td-agent-v3-to-v4).
+* Do not directly upgrade from v3 to fluent-package v5. Such a workflow is not supported. It causes a trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
 {% endhint %}
 
 ### Step 1: Install `td-agent`

--- a/installation/install-by-msi-td-agent-v4.md
+++ b/installation/install-by-msi-td-agent-v4.md
@@ -17,12 +17,10 @@ Currently two versions of `td-agent` are available.
 
 ## Step 1: Install `td-agent`
 
-{% hint style='info' %}
-NOTE: As [Drop schedule announcement about EOL of Treasure Agent (td-agent) 4](https://www.fluentd.org/blog/schedule-for-td-agent-4-eol), recommend to [Upgrade to fluent-package v5](https://www.fluentd.org/blog/upgrade-td-agent-v4-to-v5).
-{% endhint %}
-
 {% hint style='danger' %}
-NOTE: About deprecated [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), see [Install by msi Package  v3](install-by-msi-td-agent-v3.md).
+This article contains deprecated td-agent (EOL) information: SHOULD NOT use td-agent anymore.
+
+* As [Drop schedule announcement about EOL of Treasure Agent (td-agent) 4](https://www.fluentd.org/blog/schedule-for-td-agent-4-eol), recommend to [Upgrade to fluent-package v5](https://www.fluentd.org/blog/upgrade-td-agent-v4-to-v5).
 {% endhint %}
 
 Download the latest MSI installer from [the download page](https://td-agent-package-browser.herokuapp.com/4/windows). Run the installer and follow the wizard.


### PR DESCRIPTION
* some content in info should be now danger.
* note missing fluent-package on macOS