### PR TITLE
TLS1.3 added to fluentd `out_http`

### DIFF
--- a/output/http.md
+++ b/output/http.md
@@ -249,7 +249,7 @@ The verify mode of TLS.
 
 | type | default | available values | version |
 | :--- | :--- | :--- | :--- |
-| enum | TLSv1\_2 | TLSv1\_3/TLSv1\_2/TLSv1\_1 | 1.7.0 |
+| enum | TLSv1\_2 | TLSv1\_3(since 1.19.0)/TLSv1\_2/TLSv1\_1 | 1.7.0 |
 
 The default version of TLS.
 

--- a/output/http.md
+++ b/output/http.md
@@ -249,7 +249,7 @@ The verify mode of TLS.
 
 | type | default | available values | version |
 | :--- | :--- | :--- | :--- |
-| enum | TLSv1\_2 | TLSv1\_2/TLSv1\_1 | 1.7.0 |
+| enum | TLSv1\_2 | TLSv1\_3/TLSv1\_2/TLSv1\_1 | 1.7.0 |
 
 The default version of TLS.
 


### PR DESCRIPTION
Document change pretaining to the tls1.3 support for `out_http` plugin as referred in https://github.com/fluent/fluentd/pull/4859 