### PR TITLE
Fix link contains fragment

### DIFF
--- a/configuration/config-file-yaml.md
+++ b/configuration/config-file-yaml.md
@@ -447,11 +447,11 @@ If you set the environment variable `FLUENTD_TAG` to `dev`, this evaluates to `a
 
 ## Supported Data Types for Values
 
-Please refer to: [Supported Data Types for Values | Fluentd official document](./config-file#supported-data-types-for-values)
+Please refer to: [Supported Data Types for Values | Fluentd official document](./config-file.md#supported-data-types-for-values)
 
 ## Common Plugin Parameters
 
-Please refer to: [Common Plugin Parameters | Fluentd official document](./config-file#common-plugin-parameters)
+Please refer to: [Common Plugin Parameters | Fluentd official document](./config-file.md#common-plugin-parameters)
 
 ## Check Configuration File
 

--- a/how-to-guides/apache-to-minio.md
+++ b/how-to-guides/apache-to-minio.md
@@ -18,7 +18,7 @@ You can install Fluentd via major packaging systems.
 
 If [`out_s3`](../output/s3.md) (fluent-plugin-s3) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-s3 on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-s3 on your environment.
 
 {% hint style='info' %}
 If you use `fluent-package`, out_s3 (fluent-plugin-s3) is bundled by default.

--- a/how-to-guides/apache-to-mongodb.md
+++ b/how-to-guides/apache-to-mongodb.md
@@ -48,7 +48,7 @@ For MongoDB, please refer to the following downloads page:
 
 If [`out_mongo`](../output/mongo.md) (fluent-plugin-mongo) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-mongo on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-mongo on your environment.
 
 ## Configuration
 

--- a/how-to-guides/apache-to-s3.md
+++ b/how-to-guides/apache-to-s3.md
@@ -39,7 +39,7 @@ You can install Fluentd via major packaging systems.
 
 If [`out_s3` (fluent-plugin-s3)](../output/s3) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-s3 on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-s3 on your environment.
 
 {% hint style='info' %}
 If you use `fluent-package`, out_s3 (fluent-plugin-s3) is bundled by default.

--- a/how-to-guides/cep-norikra.md
+++ b/how-to-guides/cep-norikra.md
@@ -34,7 +34,7 @@ You can install Fluentd via major packaging systems.
 
 If `out_norikra` (fluent-plugin-norikra) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-norikra on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-norikra on your environment.
 
 ### Installing Norikra
 

--- a/how-to-guides/free-alternative-to-splunk-by-fluentd.md
+++ b/how-to-guides/free-alternative-to-splunk-by-fluentd.md
@@ -83,7 +83,7 @@ You can install Fluentd via major packaging systems.
 
 Next, we'll install the Elasticsearch plugin for Fluentd: fluent-plugin-elasticsearch. Then, install `fluent-plugin-elasticsearch`.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-elasticsearch on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-elasticsearch on your environment.
 
 We'll configure fluent-package \(Fluentd\) to interface properly with Elasticsearch. Please modify `/etc/fluent/fluentd.conf` as shown below:
 

--- a/how-to-guides/graylog.md
+++ b/how-to-guides/graylog.md
@@ -56,7 +56,7 @@ You can install Fluentd via major packaging systems.
 
 If `out_gelf` (fluent-plugin-gelf-hs) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-gelf-hs on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-gelf-hs on your environment.
 
 Then, configure `/etc/fluent/fluentd.conf` as follows:
 

--- a/how-to-guides/http-to-hdfs.md
+++ b/how-to-guides/http-to-hdfs.md
@@ -41,7 +41,7 @@ NOTE: CDH (Cloudera Distributed Hadoop) was discontinued. Superseded by Cloudera
 
 If `out_webhdfs` (fluent-plugin-webhdfs) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-webhdfs on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-webhdfs on your environment.
 
 {% hint style='info' %}
 If you use `fluent-package`, out_webhdfs (fluent-plugin-webhdfs) is bundled by default.

--- a/how-to-guides/kinesis-stream.md
+++ b/how-to-guides/kinesis-stream.md
@@ -40,7 +40,7 @@ You can install Fluentd via major packaging systems.
 
 If `out_kinesis_streams` (fluent-plugin-kinesis) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-kinesis on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-kinesis on your environment.
 
 ## Configuration
 

--- a/how-to-guides/logs-to-sematext.md
+++ b/how-to-guides/logs-to-sematext.md
@@ -30,7 +30,7 @@ You need to [sign up](https://apps.sematext.com/ui/registration) and create an A
 
 If [`out_elasticsearch`](../output/elasticsearch.md) (fluent-plugin-elasticsearch) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-elasticsearch on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-elasticsearch on your environment.
 
 Now you'll configure the `fluent-package` \(Fluentd\) to interface properly with Elasticsearch. Please edit `/etc/fluent/fluentd.conf` as shown below:
 

--- a/how-to-guides/splunk-like-grep-and-alert-email.md
+++ b/how-to-guides/splunk-like-grep-and-alert-email.md
@@ -22,7 +22,7 @@ You can install Fluentd via major packaging systems.
 
 If `out_grepcounter` (fluent-plugin-grepcounter) and `out_mail` (fluent-plugin-mail) are not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-mongo on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-mongo on your environment.
 
 ## Configuration
 

--- a/how-to-guides/syslog-influxdb.md
+++ b/how-to-guides/syslog-influxdb.md
@@ -62,7 +62,7 @@ Next, install the InfluxDB output plugin:
 
 If [`out_influxdb`](https://github.com/influxdata/influxdb-plugin-fluent) (fluent-plugin-influxdb-v2) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-influxdb-v2 on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-influxdb-v2 on your environment.
 
 {% hint style='warning' %}
 Do not install fluent-plugin-influxdb, it does not support for InfluxDB v2.

--- a/input/tail.md
+++ b/input/tail.md
@@ -540,7 +540,7 @@ the default Nginx access file `/var/log/nginx/access.log` is mode `0640` and own
 this case, several options are available to allow read access:
 
 1. Add the `td-agent` user to the `adm` group, e.g. through `usermod -aG`, or
-2. Use the [`cap_dac_read_search` capability](../deployment/linux-capability#capability-handling-on-in_tail)
+2. Use the [`cap_dac_read_search` capability](../deployment/linux-capability.md#capability-handling-on-in_tail)
    to allow the invoking user to read the file without otherwise changing its permission bits or ownership.
 
 A bug exists in Fluentd 1.13.x where it may suppress warning logs about unreadable files. (See Fluentd PR [#3478](https://github.com/fluent/fluentd/pull/3478).)

--- a/parser/README.md
+++ b/parser/README.md
@@ -47,7 +47,7 @@ the default Nginx access file `/var/log/nginx/access.log` is mode `0640` and own
 this case, several options are available to allow read access:
 
 1. Add the `td-agent` user to the `adm` group, e.g. through `usermod -aG`, or
-2. Use the [`cap_dac_read_search` capability](../deployment/linux-capability#capability-handling-on-in_tail)
+2. Use the [`cap_dac_read_search` capability](../deployment/linux-capability.md#capability-handling-on-in_tail)
    to allow the invoking user to read the file without otherwise changing its permission bits or ownership.
 
 ## List of Built-in Parsers


### PR DESCRIPTION
When linking to a relative path that includes a fragment, 
it seems that the file extension should be included.