### PR TITLE
docker-compose: install elasticsearch v8 gem

### DIFF
--- a/container-deployment/docker-compose.md
+++ b/container-deployment/docker-compose.md
@@ -93,6 +93,11 @@ Create `fluentd/Dockerfile` with the following content using the Fluentd [offici
 
 FROM fluent/fluentd:edge-debian
 USER root
+
+# To connect to docker.elastic.co/elasticsearch/elasticsearch:8.x, it requires elasticsearch v8 gem
+# Ref. https://github.com/elastic/elasticsearch-ruby/blob/main/README.md#compatibility
+RUN ["gem", "install", "elasticsearch", "--no-document", "--version", "8.19.0"]
+
 RUN ["gem", "install", "fluent-plugin-elasticsearch", "--no-document", "--version", "5.4.3"]
 USER fluent
 ```


### PR DESCRIPTION
Fix https://github.com/fluent/fluentd-docs-gitbook/issues/594