### PR TITLE
output: add workaround explanation with stream_buffer_size

### DIFF
--- a/output/exec_filter.md
+++ b/output/exec_filter.md
@@ -34,6 +34,8 @@ Please see the [Configuration File](../configuration/config-file.md) article for
 
 When using the JSON format in `<parse>` section, this plugin uses the `Yajl` library to parse the program output. `Yajl` buffers data internally so the output is not always instantaneous.
 
+If the buffering by `Yajl` parser is problematic for you even though you expect instantaneous response, you can tweak [`stream_buffer_size`](../parser/json.md) parameter in `<parse>` section.
+
 ## Supported Modes
 
 * Synchronous

--- a/parser/json.md
+++ b/parser/json.md
@@ -30,6 +30,8 @@ Here is a simple comparison:
 
 Set the buffer size that Yajl will use when parsing streaming input.
 
+If you specify the smaller buffer size, you could get outcome response instantaneously in exchange for performance penalty.
+
 See also: [Method: Yajl::Parser\#parse](https://www.rubydoc.info/github/brianmario/yajl-ruby/Yajl%2FParser:parse)
 
 ### `time_type`


### PR DESCRIPTION
It might be better to add explanation about workaround.

See https://github.com/fluent/fluentd/issues/5133