### PR TITLE
docs(in_exec): add command_timeout parameter documentation

### DIFF
--- a/input/exec.md
+++ b/input/exec.md
@@ -72,7 +72,7 @@ The interval time between periodic program runs. If not specified, command scrip
 
 | type | default | version |
 | :--- | :--- | :--- |
-| time | nil | 1.19.0 |
+| time | nil | 1.20.0 |
 
 Command (program) execution timeout. If the command runs longer than this value, the child process is killed.
 

--- a/input/exec.md
+++ b/input/exec.md
@@ -23,6 +23,7 @@ It is included in Fluentd's core.
     time_format %Y-%m-%d %H:%M:%S
   </extract>
   run_interval 10s
+  command_timeout 60s
 </source>
 ```
 
@@ -66,6 +67,14 @@ The tag of the output events.
 | time | nil | 0.14.0 |
 
 The interval time between periodic program runs. If not specified, command script runs only once.
+
+### `command_timeout`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| time | nil | 1.19.0 |
+
+Command (program) execution timeout. If the command runs longer than this value, the child process is killed.
 
 ### `read_block_size`
 


### PR DESCRIPTION
Add documentation for `command_timeout` option in `in_exec` plugin.

Note: The version field is set to `1.19.0` based on `fluentd/lib/fluent/version.rb`.
Please update to the appropriate release version before merging.

Related: fluent/fluentd#5319