### PR TITLE
Fix broken link to list of plugins

### DIFF
--- a/how-to-guides/splunk-like-grep-and-alert-email.md
+++ b/how-to-guides/splunk-like-grep-and-alert-email.md
@@ -117,7 +117,7 @@ Admittedly, this is a contrived example. In reality, you would set the threshold
 
 You can learn more about Fluentd and its plugins by:
 
-* exploring other [plugins](https://fluentd.org/plugin/)
+* exploring other [plugins](https://www.fluentd.org/plugins/)
 * asking questions on the [GitHub Discussions](https://github.com/fluent/fluentd/discussions)
 * [signing up for our newsletters](https://www.fluentd.org/newsletter)
 

--- a/input/README.md
+++ b/input/README.md
@@ -35,7 +35,7 @@ Input plugins extend Fluentd to retrieve and pull event logs from the external s
 
 Refer to this list of available plugins to find out about other Input plugins:
 
-* [Fluentd plugins](http://fluentd.org/plugin/)
+* [Fluentd plugins](https://www.fluentd.org/plugins/)
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
 

--- a/language-bindings/java.md
+++ b/language-bindings/java.md
@@ -102,7 +102,7 @@ Various [output plugins](../output/) are available for writing records to other 
   * [Output to MongoDB](../output/mongo.md) or [MongoDB ReplicaSet](../output/mongo_replset.md)
   * [Output to Hadoop](../output/webhdfs.md)
   * [Output to File](../output/file.md)
-  * [etc...](http://fluentd.org/plugin/)
+  * [etc...](https://www.fluentd.org/plugins/)
 
 ### High-Availability Configurations of Fluentd
 

--- a/language-bindings/nodejs.md
+++ b/language-bindings/nodejs.md
@@ -122,7 +122,7 @@ Various [output plugins](../output/) are available for writing records to other 
   * [Output to MongoDB](../output/mongo.md) or [MongoDB ReplicaSet](../output/mongo_replset.md)
   * [Output to Hadoop](../output/webhdfs.md)
   * [Output to File](../output/file.md)
-  * [etc...](http://fluentd.org/plugin/)
+  * [etc...](https://www.fluentd.org/plugins/)
 
 ### High-Availability Configurations of Fluentd
 

--- a/language-bindings/perl.md
+++ b/language-bindings/perl.md
@@ -85,7 +85,7 @@ Various [output plugins](../output/) are available for writing records to other 
   * [Output to MongoDB](../output/mongo.md) or [MongoDB ReplicaSet](../output/mongo_replset.md)
   * [Output to Hadoop](../output/webhdfs.md)
   * [Output to File](../output/file.md)
-  * [etc...](http://fluentd.org/plugin/)
+  * [etc...](https://www.fluentd.org/plugins/)
 
 ### High-Availability Configurations of Fluentd
 

--- a/language-bindings/php.md
+++ b/language-bindings/php.md
@@ -85,7 +85,7 @@ Various [output plugins](../output/) are available for writing records to other 
   * [Output to MongoDB](../output/mongo.md) or [MongoDB ReplicaSet](../output/mongo_replset.md)
   * [Output to Hadoop](../output/webhdfs.md)
   * [Output to File](../output/file.md)
-  * [etc...](http://fluentd.org/plugin/)
+  * [etc...](https://www.fluentd.org/plugins/)
 
 ### High-Availability Configurations of Fluentd
 

--- a/language-bindings/python.md
+++ b/language-bindings/python.md
@@ -84,7 +84,7 @@ Various [output plugins](../output/) are available for writing records to other 
   * [Output to MongoDB](../output/mongo.md) or [MongoDB ReplicaSet](../output/mongo_replset.md)
   * [Output to Hadoop](../output/webhdfs.md)
   * [Output to File](../output/file.md)
-  * [etc...](http://fluentd.org/plugin/)
+  * [etc...](https://www.fluentd.org/plugins/)
 
 ### High-Availability Configurations of Fluentd
 

--- a/language-bindings/ruby.md
+++ b/language-bindings/ruby.md
@@ -79,7 +79,7 @@ Various [output plugins](../output/) are available for writing records to other 
   * [Output to MongoDB](../output/mongo.md) or [MongoDB ReplicaSet](../output/mongo_replset.md)
   * [Output to Hadoop](../output/webhdfs.md)
   * [Output to File](../output/file.md)
-  * [etc...](http://fluentd.org/plugin/)
+  * [etc...](https://www.fluentd.org/plugins/)
 
 ### High-Availability Configurations of Fluentd
 

--- a/language-bindings/scala.md
+++ b/language-bindings/scala.md
@@ -108,7 +108,7 @@ Various [output plugins](../output/) are available for writing records to other 
   * [Output to MongoDB](../output/mongo.md) or [MongoDB ReplicaSet](../output/mongo_replset.md)
   * [Output to Hadoop](../output/webhdfs.md)
   * [Output to File](../output/file.md)
-  * [etc...](http://fluentd.org/plugin/)
+  * [etc...](https://www.fluentd.org/plugins/)
 
 ### High-Availability Configurations of Fluentd
 

--- a/output/README.md
+++ b/output/README.md
@@ -58,7 +58,7 @@ Output plugins in v1 can control keys of buffer chunking by configurations, dyna
 
 See this list of available plugins to find out more about other Output plugins:
 
-* [other plugins](http://fluentd.org/plugin/)
+* [other plugins](https://www.fluentd.org/plugins/)
 
 ## Difference between v1.0 and v0.12
 


### PR DESCRIPTION
https://fluentd.org/plugin/ returns a (fake) 404 while https://www.fluentd.org/plugins/ is the working URL for the list of plugins