### PR TITLE
monitor_agent: apply to change default visibility of config, retry, and debug info

### DIFF
--- a/input/monitor_agent.md
+++ b/input/monitor_agent.md
@@ -72,17 +72,35 @@ The interval time between event emits. This will be used when `tag` is configure
 
 | type | default | version |
 | :--- | :--- | :--- |
-| bool | true | 0.14.0 |
+| bool | false | 0.14.0 |
 
-You can set this option to false to remove the `config` field from the response.
+You can set this option to true to add the `config` field to the response.
+
+Since v1.19.3, the default value is changed to `false`.
+
+Note that the `config` field may contain sensitive values such as passwords. Enable this option only if you understand the risk.
 
 ### `include_retry`
 
 | type | default | version |
 | :--- | :--- | :--- |
-| bool | true | 0.14.11 |
+| bool | false | 0.14.11 |
 
-You can set this option to false to remove the `retry` field from the response.
+You can set this option to true to add the `retry` field to the response.
+
+Since v1.19.3, the default value is changed to `false`.
+
+### `include_debug_info`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| bool | false | 1.19.3 |
+
+You can set this option to true to allow the debug information to be exposed via the `debug` and `with_ivars` query parameters.
+
+Unless this option is enabled, those query parameters are ignored.
+
+Note that the debug information exposes the internal states of each plugin, including sensitive configuration values without obfuscating. Enable this option only if you understand the risk.
 
 ## Configuration Example
 
@@ -92,7 +110,7 @@ Here is a configuration example using `in_monitor_agent`:
 <source>
   @type monitor_agent
   @id in_monitor_agent
-  include_config false
+  include_retry true
 </source>
 
 <source>
@@ -165,6 +183,8 @@ If the plugin is an output plugin with the buffer settings, the metrics include 
 
 ### `retry`
 
+The `retry` field is included only when `include_retry` is set to `true`.
+
 If the output plugin is in retry status, additional fields are added to `retry`. For example, if the Elasticsearch plugin fails to flush the buffer.
 
 Here is the response:
@@ -216,13 +236,15 @@ The following list shows the available query parameters:
 
 | Parameter | Value | Explanation |
 | :--- | :--- | :--- |
-| `debug` | Constant | Expose additional internal metrics. Note that sensitive configuration value (password and so on) will be shown without obfuscating |
-| `with_ivars` | Variable names | Expose the specified instance variables of each plugin |
-| `with_config` | Boolean | Override the configuration option with\_config |
-| `with_retry` | Boolean | Override the configuration option with\_retry |
+| `debug` | Constant | Expose additional internal metrics. Requires `include_debug_info true` |
+| `with_ivars` | Variable names | Expose the specified instance variables of each plugin. Requires `include_debug_info true` |
 | `tag` | Event tag | Only show plugins that matches the specified tag |
 | `@id` | Plugin id | Filter plugins by plugin id |
 | `@type` | Plugin type | Filter plugins by plugin type |
+
+Since v1.19.3, `debug` and `with_ivars` are ignored unless `include_debug_info` is set to `true` in the configuration.
+
+Since v1.19.3, the `with_config` and `with_retry` query parameters are no longer available. The `config` and `retry` fields are controlled only by the `include_config` and `include_retry` parameters in the configuration file.
 
 ### How to emit metrics as events
 

--- a/input/monitor_agent.md
+++ b/input/monitor_agent.md
@@ -78,7 +78,9 @@ You can set this option to true to add the `config` field to the response.
 
 Since v1.19.3, the default value is changed to `false`.
 
+{% hint style='danger' %}
 Note that the `config` field may contain sensitive values such as passwords. Enable this option only if you understand the risk.
+{% endhint %}
 
 ### `include_retry`
 
@@ -100,7 +102,9 @@ You can set this option to true to allow the debug information to be exposed via
 
 Unless this option is enabled, those query parameters are ignored.
 
+{% hint style='danger' %}
 Note that the debug information exposes the internal states of each plugin, including sensitive configuration values without obfuscating. Enable this option only if you understand the risk.
+{% endhint %}
 
 ## Configuration Example
 
@@ -293,4 +297,3 @@ Three \(3\) HTTP servers will be launched with:
 Note that you may need to set `worker_id` to `@id` parameter. See [config article](../configuration/config-file.md#embedded-ruby-code).
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-

--- a/monitoring-fluentd/monitoring-rest-api.md
+++ b/monitoring-fluentd/monitoring-rest-api.md
@@ -24,36 +24,38 @@ $ curl http://host:24220/api/plugins.json
   "plugins":[
     {
       "plugin_id":"object:3fec669d6ac4",
+      "plugin_category":"input",
       "type":"forward",
       "output_plugin":false,
-      "config":{
-        "type":"forward"
-      }
+      "retry_count":null,
+      "emit_records":0,
+      "emit_size":0
     },
     {
       "plugin_id":"object:3fec669dfa48",
+      "plugin_category":"input",
       "type":"monitor_agent",
       "output_plugin":false,
-      "config":{
-        "type":"monitor_agent",
-        "port":"24220"
-      }
+      "retry_count":null,
+      "emit_records":0,
+      "emit_size":0
     },
     {
       "plugin_id":"object:3fec66aead48",
+      "plugin_category":"output",
       "type":"forward",
       "output_plugin":true,
       "buffer_queue_length":0,
       "buffer_total_queued_size":0,
       "retry_count":0,
-      "config":{
-        "type":"forward",
-        "host":"192.168.0.11"
-      }
+      "emit_records":0,
+      "emit_size":0
     }
   ]
 }
 ```
+
+Since v1.19.3, the `config` and `retry` fields are not included by default. Set `include_config` or `include_retry` to `true` if you need them.
 
 See [`in_monitor_agent`](../input/monitor_agent.md) article for more detail.
 


### PR DESCRIPTION
Apply Fluentd v1.19.3 changes.

Ref. https://github.com/fluent/fluentd/pull/5392