### PR TITLE
docs: fix grammar mistakes and typos across the documentation

### DIFF
--- a/appendix/td-agent-v2-vs-v3-vs-v4.md
+++ b/appendix/td-agent-v2-vs-v3-vs-v4.md
@@ -59,5 +59,5 @@ This is for v0.12 and old distribution users. We don't recommend this version fo
 * [macOS](../installation/install-by-dmg-td-agent-v4.md)
 * [RubyGems](../installation/install-by-gem.md)
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under under [the Apache License 2.0.](https://www.apache.org/licenses/LICENSE-2.0)
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under [the Apache License 2.0.](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/configuration/buffer-section.md
+++ b/configuration/buffer-section.md
@@ -405,16 +405,16 @@ Following are the configuration parameters for buffer plugin and its chunks:
 
 * `chunk_limit_size` \[size\]
   * Default: 8MB \(memory\) / 256MB \(file\)
-  * The max size of each chunks: events will be written into chunks until
+  * The max size of each chunk: events will be written into chunks until
 
-    the size of chunks become this size
+    the size of chunks becomes this size
 * `chunk_limit_records` \[integer\]
   * Optional
-  * The max number of events that each chunks can store in it
+  * The max number of events that each chunk can store in it
 * `total_limit_size` \[size\]
   * Default: 512MB \(memory\) / 64GB \(file\)
   * The size limitation of this buffer plugin instance
-  * Once the total size of stored buffer reached this threshold, all append
+  * Once the total size of stored buffer reaches this threshold, all append
 
     operations will fail with error \(and data will be lost\)
 * `queue_limit_length` \[integer\]

--- a/configuration/config-file-yaml.md
+++ b/configuration/config-file-yaml.md
@@ -15,7 +15,7 @@ See also: [Lifecycle of a Fluentd Event](../quickstart/life-of-a-fluentd-event.m
 
 Fluentd starts to support YAML configuration format but this is not 1-by-1 correspondence for Fluentd config file syntax.
 
-Normal Fluentd configuration syntax has the following the list of directives:
+Normal Fluentd configuration syntax has the following list of directives:
 
 1. **`source`** directives determine the input sources
 2. **`match`** directives determine the output destinations
@@ -42,7 +42,7 @@ Under `config` object, Fluentd will handle the following elements:
 ### Special YAML elements
 
 1. **`!include`** defines including rules for other files
-2. **`!fluent/s`** defines Fluentd string format that is equivalent for double quoted string
+2. **`!fluent/s`** defines Fluentd string format that is equivalent to double quoted string
 3. **`!fluent/json`** defines Fluentd JSON format that is used for Hash type object
 4. **`$tag`** defines tag for output plugin
 5. **`$label`** defines label routes for input plugin
@@ -243,7 +243,7 @@ If `$label` with  `$name: '@ERROR'` is set, the events are routed to this label 
 
 The `@ROOT` label is a builtin label used for getting root router by plugin's `event_emitter_router` API.
 
-This label is introduced since v1.14.0 to assign a label back to the default route. For example, timed-out event records are handled by the concat filter can be sent to the default route.
+This label is introduced since v1.14.0 to assign a label back to the default route. For example, timed-out event records handled by the concat filter can be sent to the default route.
 
 ## 6. Limit to specific workers: the `worker` element
 

--- a/configuration/config-file.md
+++ b/configuration/config-file.md
@@ -25,7 +25,7 @@ $ sudo vi /etc/fluent/fluentd.conf
 #### td-agent (EOL)
 
 {% hint style='warning' %}
-As `td-agent` had already reached EOL, we recommend to use `fluent-package` (the successor to `td-agent`).
+As `td-agent` had already reached EOL, we recommend using `fluent-package` (the successor to `td-agent`).
 
 * [fluent-package v5 vs td-agent v4](../quickstart/fluent-package-v5-vs-td-agent.md)
 {% endhint %}
@@ -289,7 +289,7 @@ If `<label @ERROR>` is set, the events are routed to this label when the related
 
 The `@ROOT` label is a builtin label used for getting root router by plugin's `event_emitter_router` API.
 
-This label is introduced since v1.14.0 to assign a label back to the default route. For example, timed-out event records are handled by the concat filter can be sent to the default route.
+This label is introduced since v1.14.0 to assign a label back to the default route. For example, timed-out event records handled by the concat filter can be sent to the default route.
 
 ## 6. Limit to specific workers: the `worker` directive
 

--- a/configuration/parse-section.md
+++ b/configuration/parse-section.md
@@ -203,7 +203,7 @@ For the `types` parameter, the following types are supported:
 
 * **`time_format_fallbacks`** \(\) \(optional\): uses the specified time format as a fallback in the specified order.
 
-  You can parse undetermined time format by using `time_format_fallbacks`. This options is enabled when `time_type` is `mixed`.
+  You can parse undetermined time format by using `time_format_fallbacks`. This option is enabled when `time_type` is `mixed`.
 
   * Default: `nil`
 

--- a/configuration/routing-examples.md
+++ b/configuration/routing-examples.md
@@ -87,7 +87,7 @@ Label reduces complex `tag` handling by separating data pipelines.
 
 ## Reroute Event by Tag
 
-Use [fluent-plugin-route](https://github.com/tagomoris/fluent-plugin-route) plugin. This plugin rewrites `tag` and re-emit events to other `match` or Label.
+Use [fluent-plugin-route](https://github.com/tagomoris/fluent-plugin-route) plugin. This plugin rewrites `tag` and re-emits events to other `match` or Label.
 
 ```text
 <match worker.**>

--- a/configuration/transport-section.md
+++ b/configuration/transport-section.md
@@ -95,7 +95,7 @@ The max size of socket receive buffer for TCP/UDP. This is used in `SO_RCVBUF` s
   * Default: `false`
   * Version: 1.18.0
   * Specifies whether it must use FIPS mode with OpenSSL. If `true`, Fluentd will check FIPS mode is supported in your environment, if not, just aborts.
-    If `false`, it does nothing and don't care FIPS mode with OpenSSL.
+    If `false`, it does nothing and doesn't care about FIPS mode with OpenSSL.
 
 If you want to accept multiple TLS protocols, use `min_version`/`max_version` instead of `version`. To support the old style, fluentd accepts `TLS1_1` and `TLSv1_1` values.
 

--- a/container-deployment/docker-compose.md
+++ b/container-deployment/docker-compose.md
@@ -6,7 +6,7 @@ This article explains how to collect [Docker](https://www.docker.com/) logs and 
 
 [Elasticsearch](https://www.elastic.co/products/elasticsearch) had been an open-source search engine known for its ease of use. [Kibana](https://www.elastic.co/products/kibana) had been an open-source Web UI that makes Elasticsearch user-friendly for marketers, engineers and data scientists alike.
 
-NOTE: Since v7.11, These products are distributed under non open-source license (Dual licensed under Server Side Public License and Elastic License)
+NOTE: Since v7.11, These products are distributed under a non open-source license (Dual licensed under Server Side Public License and Elastic License)
 
 
 By combining these three tools EFK \(Elasticsearch + Fluentd + Kibana\) we get a scalable, flexible, easy to use log collection and analytics pipeline. In this article, we will set up four \(4\) containers, each includes:

--- a/container-deployment/docker-logging-driver.md
+++ b/container-deployment/docker-logging-driver.md
@@ -1,6 +1,6 @@
 # Docker Logging Driver
 
-The article describes how to implement a unified logging system for your [Docker](http://www.docker.com) containers. An application in a production environment requires to register certain events or problems during its runtime.
+The article describes how to implement a unified logging system for your [Docker](http://www.docker.com) containers. An application in a production environment needs to register certain events or problems during its runtime.
 
 The old-fashioned way is to write these messages into a log file, but that inherits certain problems. Specifically, when we try to perform some analysis over the registers, or on the other hand, if the application has multiple instances running, the scenario becomes even more complex.
 
@@ -130,7 +130,7 @@ Then you provide the log message with JSON format:
 $ docker run --log-driver=fluentd --log-opt tag=docker ubuntu echo "{\"key\":\"value\"}"
 ```
 
-About `--log-opt tag=...`, please refer at [Driver Options](#driver-options) section.
+About `--log-opt tag=...`, please refer to the [Driver Options](#driver-options) section.
 
 Original Event (without filter plugin):
 
@@ -148,7 +148,7 @@ Filtered Event:
 
 The application log is stored in the `log` field of the record. You can concatenate these logs by using [`fluent-plugin-concat`](https://github.com/fluent-plugins-nursery/fluent-plugin-concat) filter before sending it to the destinations.
 
-At first, you need to create custom docker image due to install the `fluent-plugin-concat` gem in the Fluentd container.
+At first, you need to create a custom docker image to install the `fluent-plugin-concat` gem in the Fluentd container.
 
 Create `Dockerfile` with the following content:
 
@@ -197,7 +197,7 @@ Launch the Fluentd container:
 $ docker run -it -p 24224:24224 -v $(pwd)/demo.conf:/fluentd/etc/demo.conf -e FLUENTD_CONF=demo.conf fluentd-test
 ```
 
-Then you provide the log message contains newlines:
+Then you provide the log message containing newlines:
 
 ```text
 $ docker run --log-driver=fluentd --log-opt tag=docker ubuntu echo "-e:2:in \`/'"$'\n'"-e:2:in \`do_division_by_zero'"$'\n'"-e:4:in \`<main>'"
@@ -262,7 +262,7 @@ $ docker run --log-driver=fluentd --log-opt fluentd-address=192.168.2.4:24225 ub
 $ docker run --log-driver=fluentd --log-opt tag=docker.my_new_tag ubuntu echo "..."
 ```
 
-Additionally, this option allows to specify some internal variables such as `{{.ID}}`, `{{.FullID}}` or `{{.Name}}` like this:
+Additionally, this option allows you to specify some internal variables such as `{{.ID}}`, `{{.FullID}}` or `{{.Name}}` like this:
 
 ```text
 $ docker run --log-driver=fluentd --log-opt tag=docker.{{.ID}} ubuntu echo "..."

--- a/container-deployment/kubernetes.md
+++ b/container-deployment/kubernetes.md
@@ -29,7 +29,7 @@ Before getting started, make sure you understand or have a basic idea about the 
 
   > A DaemonSet ensures that all \(or some\) nodes run a copy of a pod. As nodes are added to the cluster, pods are added to them. As nodes are removed from the cluster, those pods are garbage collected. Deleting a DaemonSet will clean up the pods it created...
 
-Since applications runs in Pods and multiple Pods might exists across multiple nodes, we need a specific Fluentd-Pod that takes care of log collection on each node: Fluentd DaemonSet.
+Since applications run in Pods and multiple Pods might exist across multiple nodes, we need a specific Fluentd-Pod that takes care of log collection on each node: Fluentd DaemonSet.
 
 ## Fluentd DaemonSet
 
@@ -41,7 +41,7 @@ The following steps will focus on sending the logs to an Elasticsearch Pod:
 
 ### Get Fluentd DaemonSet sources
 
-We have created a Fluentd DaemonSet that have the proper rules and container image ready to get started:
+We have created a Fluentd DaemonSet that has the proper rules and container image ready to get started:
 
 * [https://github.com/fluent/fluentd-kubernetes-daemonset](https://github.com/fluent/fluentd-kubernetes-daemonset)
 
@@ -53,7 +53,7 @@ $ git clone https://github.com/fluent/fluentd-kubernetes-daemonset
 
 ### DaemonSet Content
 
-The cloned repository contains several configurations that allow to deploy Fluentd as a DaemonSet. The Docker container image distributed on the repository also comes pre-configured so that Fluentd can gather all the logs from the Kubernetes node's environment and append the proper metadata to the logs.
+The cloned repository contains several configurations that allow you to deploy Fluentd as a DaemonSet. The Docker container image distributed on the repository also comes pre-configured so that Fluentd can gather all the logs from the Kubernetes node's environment and append the proper metadata to the logs.
 
 This repository has several presets for Alpine/Debian with popular outputs:
 
@@ -100,7 +100,7 @@ This YAML file contains two relevant environment variables that are used by Flue
 | :--- | :--- | :---: |
 | `FLUENT_ELASTICSEARCH_HOST` | Specify the host name or IP address. | `elasticsearch-logging` |
 | `FLUENT_ELASTICSEARCH_PORT` | Elasticsearch TCP port | 9200 |
-| `FLUENT_ELASTICSEARCH_SSL_VERIFY` | Whether verify SSL certificates or not. | `true` |
+| `FLUENT_ELASTICSEARCH_SSL_VERIFY` | Whether to verify SSL certificates or not. | `true` |
 | `FLUENT_ELASTICSEARCH_SSL_VERSION` | Specify the version of TLS. | `TLSv1_2` |
 
 Any relevant change needs to be done in the YAML file before deployment. The defaults assume that at least one Elasticsearch Pod **elasticsearch-logging** exists in the cluster.

--- a/deployment/command-line-option.md
+++ b/deployment/command-line-option.md
@@ -1,6 +1,6 @@
 # Command Line Option
 
-This article describes the command-line tools and its options in `fluentd` project.
+This article describes the command-line tools and their options in `fluentd` project.
 
 ## `fluentd`
 

--- a/deployment/fluentd-ui.md
+++ b/deployment/fluentd-ui.md
@@ -8,7 +8,7 @@
 * View Fluentd log with simple error viewer
 
 {% hint style='danger' %}
-`fluentd-ui` does not maintained anymore. It won't work with `fluent-package`. This content is for v0.12 for now.
+`fluentd-ui` is not maintained anymore. It won't work with `fluent-package`. This content is for v0.12 for now.
 {% endhint %}
 
 ## Enterprise

--- a/deployment/high-availability.md
+++ b/deployment/high-availability.md
@@ -38,7 +38,7 @@ To configure Fluentd for high-availability, we assume that your network consists
 
 ![Fluentd&apos;s High-Availability Overview](../.gitbook/assets/fluentd_ha%20%281%29%20%281%29%20%281%29.png)
 
-'**Log forwarders**' are typically installed on every node to receive local events. Once an event is received, they forward it to the 'log aggregators' through the network. For log forwarders, [fluent-bit](https://fluentbit.io/) is also good candidate for light-weight processing.
+'**Log forwarders**' are typically installed on every node to receive local events. Once an event is received, they forward it to the 'log aggregators' through the network. For log forwarders, [fluent-bit](https://fluentbit.io/) is also a good candidate for light-weight processing.
 
 '**Log aggregators**' are daemons that continuously receive events from the log forwarders. They buffer the events and periodically upload the data into the cloud.
 

--- a/deployment/linux-capability.md
+++ b/deployment/linux-capability.md
@@ -20,7 +20,7 @@ Linux capabilities grant privileges to processes and executables that are otherw
 
 Fluentd uses the [`capng_c` gem](https://github.com/fluent-plugins-nursery/capng_c) to handle Linux capabilities.
 
-Add this line to your Fluentd' or td-agent's Gemfile:
+Add this line to your Fluentd's or td-agent's Gemfile:
 
 ```ruby
 gem 'capng_c'
@@ -183,7 +183,7 @@ If this article is incorrect or outdated, or omits critical information, please 
 
 ## Capability handling on docker container
 If you would like to collect logs from a file as a non-root user, you can use `CAP_DAC_READ_SEARCH` Linux capabilities.
-However, `CAP_DAC_READ_SEARCH` now cannot be used on docker container by default.
+However, `CAP_DAC_READ_SEARCH` now cannot be used on a docker container by default.
 
 When using `CAP_DAC_READ_SEARCH` in a Docker container, you need to add the `--cap-add DAC_READ_SEARCH` option to the `docker run` command.
 Or, if you are using `docker compose`, you need to add `cap_add` to the service definition.

--- a/deployment/logging.md
+++ b/deployment/logging.md
@@ -79,7 +79,7 @@ If you do not specify the `@log_level` parameter, the plugin will use the global
 
 ## Log Format
 
-Following format are supported:
+Following formats are supported:
 
 * `text` \(default\)
 * `json`
@@ -122,7 +122,7 @@ Fluentd provides two parameters to suppress log/stacktrace messages
 </system>
 ```
 
-Under high loaded environment, output destination sometimes becomes unstable and it causes lots of same log message. This parameter mitigates such situation.
+Under high loaded environment, output destination sometimes becomes unstable and it causes lots of same log messages. This parameter mitigates such situation.
 
 ### `ignore_same_log_interval`
 
@@ -158,7 +158,7 @@ $ fluentd -o /path/to/log_file
 
 ### By Config File
 
-Since v1.18.0, You can also configure the log file path using the `<log>` directive under `<system>`:
+Since v1.18.0, you can also configure the log file path using the `<log>` directive under `<system>`:
 
 ```text
 <system>

--- a/deployment/multi-process-workers.md
+++ b/deployment/multi-process-workers.md
@@ -8,7 +8,7 @@ This feature can simply replace `fluent-plugin-multiprocess`.
 
 By default, one instance of `fluentd` launches a supervisor and a worker. A worker consists of input/filter/output plugins.
 
-The **multi-process workers** feature launches multiple workers and use a separate process per worker. `fluentd` provides several features for multi-process workers.
+The **multi-process workers** feature launches multiple workers and uses a separate process per worker. `fluentd` provides several features for multi-process workers.
 
 ![Multi-process Workers](../.gitbook/assets/multi-process-workers%20%281%29%20%281%29.png)
 
@@ -211,7 +211,7 @@ You may see following error in the fluentd logs:
 2018-10-01 10:00:00 +0900 [error]: config error file="/path/to/fluentd.conf" error_class=Fluent::ConfigError error="Plugin 'tail' does not support multi workers configuration (Fluent::Plugin::TailInput)"
 ```
 
-This means that the configured plugin does not support multi-process workers. All configured plugins must support multi-process workers. See "Multi-Process Worker and Plugins" section above.
+This means that the configured plugin does not support multi-process workers. All configured plugins must support multi-process workers. See "Multi-Process Workers and Plugins" section above.
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
 

--- a/deployment/plugin-management.md
+++ b/deployment/plugin-management.md
@@ -21,10 +21,10 @@ Any fluentd plugin can unknowingly break fluentd completely (and possibly break 
 There is no way to block this kind of situation. This is because the problem itself is derived from plug-in mechanism, and that's Lightweight Language.
 One solution is "Do not use unreliable plugins".
 
-Generally speaking, plug-in mechanism can break core functionality not only Fluentd but also in most other software.
+Generally speaking, plug-in mechanism can break core functionality not only in Fluentd but also in most other software.
 We shouldn't use unreliable plugins in any software.
 
-We recommend to send feedback to plugin owner if you faced such a fault in plugins.
+We recommend sending feedback to plugin owner if you faced such a fault in plugins.
 
 ### If Using `td-agent`, Use `/usr/sbin/td-agent-gem`
 
@@ -80,7 +80,7 @@ For `td-agent`, Fluentd uses the `/etc/td-agent/plugin` directory instead of `/e
 
 Fluentd and plugins are evolving so you may hit an unexpected error with the latest version e.g. regression by a new feature, remove a deprecated parameter, change library dependency, etc. To avoid these problems, we recommend fixing fluentd and plugin version on production. If you want to update fluentd or plugins, check the behavior first on your test environment. For example, td-agent fixes fluentd and plugins version in each release.
 
-Fluentd plugins are RubyGems and RubyGems installs the latest version by default. So we don't recommend to execute following commands on production:
+Fluentd plugins are RubyGems and RubyGems installs the latest version by default. So we don't recommend executing the following commands on production:
 
 * `gem install fluentd`
 * `gem install fluent-plugin-elasticsearch`

--- a/deployment/signals.md
+++ b/deployment/signals.md
@@ -44,7 +44,7 @@ See [Zero-downtime restart](zero-downtime-restart.md) for details.
 
 **Comparison with SIGHUP**
 
-`SIGHUP` gracefully restarting the worker process to reload.
+`SIGHUP` gracefully restarts the worker process to reload.
 
 This method does not cause socket downtime, so if there is no need to restart the supervisor, `SIGHUP` is a lighter zero-downtime restart method.
 

--- a/deployment/source-only-mode.md
+++ b/deployment/source-only-mode.md
@@ -45,7 +45,7 @@ Please see the following for details.
 
 ### Recovery
 
-If Fluentd stops with the temporary buffer remained, you need to recover the buffer to launch Fluentd with source-only mode again.
+If Fluentd stops with the temporary buffer remaining, you need to recover the buffer to launch Fluentd with source-only mode again.
 
 Note that a different path will be used each time unless you configure the temporary buffer path explicitly.
 In this case, you can recover the buffer as follows.
@@ -54,7 +54,7 @@ In this case, you can recover the buffer as follows.
 1. Start Fluentd with source-only mode again.
 1. Send `SIGWINCH` to the supervisor to load the buffer.
 
-If this recovery is necessary, i.e., Fluentd stops with the temporary buffer remained, the following warning log will be displayed.
+If this recovery is necessary, i.e., Fluentd stops with the temporary buffer remaining, the following warning log will be displayed.
 You can confirm the path to configure by this log.
 
 ```

--- a/deployment/system-config.md
+++ b/deployment/system-config.md
@@ -22,7 +22,7 @@ Specifies the number of workers.
 | :--- | :--- | :--- |
 | time | 0 | 1.15.0 |
 
-Specifies interval to restart workers that has stopped for some reason. By default, Fluentd immediately restarts stopped workers. You can use this option for stopping workers for a certain period of time.
+Specifies interval to restart workers that have stopped for some reason. By default, Fluentd immediately restarts stopped workers. You can use this option for stopping workers for a certain period of time.
 
 ### `root_dir`
 
@@ -176,7 +176,7 @@ Parses config values strictly. Invalid numerical or boolean values are not allow
 | :--- | :--- | :--- |
 | bool | nil | 1.12.1 |
 
-Force disable the shared socket which is for listening a same port across multiple worker processes. When the shared socket is enabled \(it's the default behavior\), a socket is always created to enable workers to communicate with the supervisor. On Windows, it consumes a dynamic \(a.k.a ephemeral\) TCP port. If you don't prefer it, set this option as `true`. When it's disabled, you may not use plugins that listen a port such as in\_forward, in\_http and in\_syslog.
+Force disable the shared socket which is for listening on the same port across multiple worker processes. When the shared socket is enabled \(it's the default behavior\), a socket is always created to enable workers to communicate with the supervisor. On Windows, it consumes a dynamic \(a.k.a ephemeral\) TCP port. If you don't prefer it, set this option as `true`. When it's disabled, you may not use plugins that listen on a port such as in\_forward, in\_http and in\_syslog.
 
 ### `config_include_dir`
 

--- a/deployment/trouble-shooting.md
+++ b/deployment/trouble-shooting.md
@@ -69,12 +69,12 @@ On Windows, you can use [fluent-ctl](command-line-option.md#fluent-ctl).
 
 ## High CPU Usage Issue
 
-If `fluentd` suddenly hits unexpected high CPU usage problem, there are several reasons:
+If `fluentd` suddenly hits an unexpected high CPU usage problem, there are several reasons:
 
 * a plugin has a race condition or similar bug
 * dependent gems have a bug
 * regular expression with broken data
-* system calls has a bug, e.g. `inotify` with lots of files
+* system calls have a bug, e.g. `inotify` with lots of files
 
 In such cases, you can use `perf` tool on recent Linux to investigate the problem. See [Linux perf Examples](http://www.brendangregg.com/perf.html) page. If you want to know which call causes the problem, [`pid2line.rb`](https://gist.github.com/nurse/0619b6af90df140508c2) is useful.
 

--- a/deployment/zero-downtime-restart.md
+++ b/deployment/zero-downtime-restart.md
@@ -35,7 +35,7 @@ You can use this feature in the following ways.
      * For details on the temporary buffer, see [Source Only Mode - Temporary file buffer](source-only-mode.md#temporary-file-buffer).
    * Send `SIGTERM` to the old supervisor after `10s` delay.
 5. The old supervisor stops and sends `SIGWINCH` to the new one.
-6. The new workers starts to run fully.
+6. The new workers start to run fully.
    * The temporary buffer of source-only mode starts to load.
 
 ## Plugins: how to support this feature

--- a/filter/README.md
+++ b/filter/README.md
@@ -51,7 +51,7 @@ Like the `<match>` directive for output plugins, `<filter>` matches against a ta
 </filter>
 ```
 
-Only the events whose `message` field contain `cool` get the new field `hostname` with the machine's hostname as its value.
+Only the events whose `message` field contains `cool` get the new field `hostname` with the machine's hostname as its value.
 
 Users can create their own custom plugins with a bit of Ruby. See [this section](../plugin-development/#filter-plugins) for more information.
 

--- a/filter/geoip.md
+++ b/filter/geoip.md
@@ -106,7 +106,7 @@ Specifies one or more geoip lookup fields containing the IP address.
 
 See [`record_accessor`](../plugin-helper-overview/api-plugin-helper-record_accessor.md) about nested attributes.
 
-**NOTE**: Since v1.3.0 does not interpret `host.ip` as a nested attribute.
+**NOTE**: Since v1.3.0, Fluentd does not interpret `host.ip` as a nested attribute.
 
 ### `geoip_lookup_key`
 

--- a/filter/grep.md
+++ b/filter/grep.md
@@ -74,7 +74,7 @@ Specifies the filtering rule. This directive contains either `<regexp>` or `<exc
 </and>
 ```
 
-This is same as below:
+This is the same as below:
 
 ```text
 <regexp>
@@ -122,7 +122,7 @@ Specifies the filtering rule. This directive contains either `<regexp>` or `<exc
 </or>
 ```
 
-This is same as below:
+This is the same as below:
 
 ```text
 <exclude>

--- a/filter/parser.md
+++ b/filter/parser.md
@@ -113,7 +113,7 @@ Above incoming event is parsed as:
 
 ```text
 time:
-2021-06-24 14:33:35.475115751 +0900 (It vary on parsed timestamp)
+2021-06-24 14:33:35.475115751 +0900 (It varies on parsed timestamp)
 
 record:
 {
@@ -162,7 +162,7 @@ Without `reserve_data`, the result is:
 | :--- | :--- | :--- |
 | bool | false | 1.2.2 |
 
-Removes `key_name` field when parsing is succeeded.
+Removes `key_name` field when parsing succeeds.
 
 ```text
 <filter foo.bar>

--- a/filter/record_transformer.md
+++ b/filter/record_transformer.md
@@ -124,7 +124,7 @@ For `NEW_FIELD` and `NEW_VALUE`, a special syntax `${}` allows the user to gener
 
   [`Socket.gethostname`](https://docs.ruby-lang.org/en/trunk/Socket.html#method-c-gethostname).
 
-You can also access to a certain portion of a tag using the following notations:
+You can also access a certain portion of a tag using the following notations:
 
 * `tag_parts[N]` refers to the `Nth` part of the tag.
 * `tag_prefix[N]` refers to the `[0..N]` part of the tag.
@@ -163,7 +163,7 @@ foo_${record["key"]} bar_${record["value"]}
 nested_value ${record["payload"]["key"]}
 ```
 
-By historical reason, `enable_ruby true` is too slow. If you need this option, consider `record_modifier` filter instead. See also `Need more performance?` section.
+For historical reasons, `enable_ruby true` is too slow. If you need this option, consider `record_modifier` filter instead. See also `Need more performance?` section.
 
 ### `auto_typecast`
 

--- a/formatter/csv.md
+++ b/formatter/csv.md
@@ -1,6 +1,6 @@
 # csv
 
-The `csv` formatter plugin output an event as CSV.
+The `csv` formatter plugin outputs an event as CSV.
 
 ```text
 "value1"[delimiter]"value2"[delimiter]"value3"[newline]

--- a/formatter/json.md
+++ b/formatter/json.md
@@ -1,6 +1,6 @@
 # json
 
-The `json` formatter plugin format an event to JSON.
+The `json` formatter plugin formats an event to JSON.
 
 By default, `json` formatter result doesn't contain `tag` and `time` fields.
 

--- a/formatter/ltsv.md
+++ b/formatter/ltsv.md
@@ -1,6 +1,6 @@
 # ltsv
 
-The `ltsv` formatter plugin output an event as [LTSV](http://ltsv.org).
+The `ltsv` formatter plugin outputs an event as [LTSV](http://ltsv.org).
 
 ```text
 field1[label_delimiter]value1[delimiter]field2[label_delimiter]value2[newline]
@@ -49,7 +49,7 @@ Specify newline characters.
 | :--- | :--- | :--- |
 | string | \`\` \(SPACE\) | 1.12.2 |
 
-Safe replacement to substitute delimiters characters in records.
+Safe replacement to substitute delimiter characters in records.
 
 ## Example
 

--- a/formatter/single_value.md
+++ b/formatter/single_value.md
@@ -1,6 +1,6 @@
 # single\_value
 
-The `single_value` formatter plugin output the value of a single field instead of the whole record.
+The `single_value` formatter plugin outputs the value of a single field instead of the whole record.
 
 This formatter is often used in conjunction with [`none` parser](../parser/none.md) in input plugin.
 

--- a/formatter/tsv.md
+++ b/formatter/tsv.md
@@ -1,6 +1,6 @@
 # tsv
 
-The `tsv` formatter plugin converts an event as TSV.
+The `tsv` formatter plugin converts an event to TSV.
 
 ```text
 value1[delimiter]value2[newline]
@@ -59,7 +59,7 @@ In non-Windows:
 192.168.0.1\t777\tPUT\n
 ```
 
-In non-Windows:
+In Windows:
 
 ```text
 192.168.0.1\t777\tPUT\r\n

--- a/formatter/tsv.md
+++ b/formatter/tsv.md
@@ -53,17 +53,16 @@ record: {"host":"192.168.0.1","size":777,"method":"PUT"}
 
 This incoming event is formatted to:
 
-In non-Windows:
+On non-Windows:
 
 ```text
 192.168.0.1\t777\tPUT\n
 ```
 
-In Windows:
+On Windows:
 
 ```text
 192.168.0.1\t777\tPUT\r\n
 ```
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-

--- a/how-to-guides/apache-to-minio.md
+++ b/how-to-guides/apache-to-minio.md
@@ -18,7 +18,7 @@ You can install Fluentd via major packaging systems.
 
 If [`out_s3`](../output/s3.md) (fluent-plugin-s3) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-s3 on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-s3 on your environment.
 
 {% hint style='info' %}
 If you use `fluent-package`, out_s3 (fluent-plugin-s3) is bundled by default.

--- a/how-to-guides/apache-to-mongodb.md
+++ b/how-to-guides/apache-to-mongodb.md
@@ -48,7 +48,7 @@ For MongoDB, please refer to the following downloads page:
 
 If [`out_mongo`](../output/mongo.md) (fluent-plugin-mongo) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-mongo on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-mongo on your environment.
 
 ## Configuration
 

--- a/how-to-guides/apache-to-s3.md
+++ b/how-to-guides/apache-to-s3.md
@@ -39,7 +39,7 @@ You can install Fluentd via major packaging systems.
 
 If [`out_s3` (fluent-plugin-s3)](../output/s3) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-s3 on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-s3 on your environment.
 
 {% hint style='info' %}
 If you use `fluent-package`, out_s3 (fluent-plugin-s3) is bundled by default.

--- a/how-to-guides/cep-norikra.md
+++ b/how-to-guides/cep-norikra.md
@@ -34,7 +34,7 @@ You can install Fluentd via major packaging systems.
 
 If `out_norikra` (fluent-plugin-norikra) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-norikra on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-norikra on your environment.
 
 ### Installing Norikra
 
@@ -95,7 +95,7 @@ The output destination will be Norikra. The output configuration should look lik
 
 The `<match>` section specifies the glob pattern used to look for the matching tags. If the tag of a log is matched, the respective `match` configuration is used \(i.e. the log is routed accordingly\).
 
-The `norikra` attribute specifies the Norikra server's RPC host and port \(default: `26571`\). By `target_map_tag true` and `remove_tag_prefix data`, `out_norikra` handle the rest of tags \(e.g. `foo` for `data.foo`\) as the target, which is the name of the set of events as same as table name of RDBMS.
+The `norikra` attribute specifies the Norikra server's RPC host and port \(default: `26571`\). By `target_map_tag true` and `remove_tag_prefix data`, `out_norikra` handles the rest of tags \(e.g. `foo` for `data.foo`\) as the target, which is the name of the set of events the same as table name of RDBMS.
 
 The `<default>` section specifies which fields are sent to the Norikra server. We can also specify these sets per target with `<target NAME>...</target>`. For more details, refer to [`fluent-plugin-norikra`](https://github.com/norikra/fluent-plugin-norikra).
 

--- a/how-to-guides/cep-norikra.md
+++ b/how-to-guides/cep-norikra.md
@@ -95,7 +95,7 @@ The output destination will be Norikra. The output configuration should look lik
 
 The `<match>` section specifies the glob pattern used to look for the matching tags. If the tag of a log is matched, the respective `match` configuration is used \(i.e. the log is routed accordingly\).
 
-The `norikra` attribute specifies the Norikra server's RPC host and port \(default: `26571`\). By `target_map_tag true` and `remove_tag_prefix data`, `out_norikra` handles the rest of tags \(e.g. `foo` for `data.foo`\) as the target, which is the name of the set of events the same as table name of RDBMS.
+The `norikra` attribute specifies the Norikra server's RPC host and port \(default port: `26571`\). With `target_map_tag true` and `remove_tag_prefix data`, `out_norikra` handles the rest of tags \(e.g. `foo` for `data.foo`\) as the target. A target is the name of a set of events, similar to a table name in an RDBMS.
 
 The `<default>` section specifies which fields are sent to the Norikra server. We can also specify these sets per target with `<target NAME>...</target>`. For more details, refer to [`fluent-plugin-norikra`](https://github.com/norikra/fluent-plugin-norikra).
 

--- a/how-to-guides/free-alternative-to-splunk-by-fluentd.md
+++ b/how-to-guides/free-alternative-to-splunk-by-fluentd.md
@@ -53,8 +53,8 @@ $ ./bin/elasticsearch
 
 {% hint style='info' %}
 * You can also install Elasticsearch \(and Kibana\) using RPM/DEB packages. For details, please refer to [the official instructions](https://www.elastic.co/downloads).
-* You can create enrollment token for kibana. Use `./bin/elasticsearch-create-enrollment-token -s kibana`.
-* You can reset default password for `elastic`, Use `./bin/elasticsearch-reset-password -u elastic`.
+* You can create an enrollment token for kibana. Use `./bin/elasticsearch-create-enrollment-token -s kibana`.
+* You can reset the default password for `elastic`, Use `./bin/elasticsearch-reset-password -u elastic`.
 {% endhint %}
 
 ### Set Up Kibana
@@ -83,7 +83,7 @@ You can install Fluentd via major packaging systems.
 
 Next, we'll install the Elasticsearch plugin for Fluentd: fluent-plugin-elasticsearch. Then, install `fluent-plugin-elasticsearch`.
 
-See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-elasticsearch on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-elasticsearch on your environment.
 
 We'll configure fluent-package \(Fluentd\) to interface properly with Elasticsearch. Please modify `/etc/fluent/fluentd.conf` as shown below:
 

--- a/how-to-guides/graylog.md
+++ b/how-to-guides/graylog.md
@@ -37,7 +37,7 @@ Then, from the dropdown, choose `GELF UDP` and click on `Launch new input`, whic
 Now, Graylog is ready to accept messages from Fluentd over UDP. It is time to configure Fluentd.
 
 {% hint style='info' %}
-There might be a case that modal dialogue will not shown when clicking `Launch new input`. Check your browser configuration.
+There might be a case that modal dialogue will not be shown when clicking `Launch new input`. Check your browser configuration.
 {% endhint %}
 
 ### Fluentd
@@ -50,7 +50,7 @@ You can install Fluentd via major packaging systems.
 
 If `out_gelf` (fluent-plugin-gelf-hs) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-gelf-hs on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-gelf-hs on your environment.
 
 Then, configure `/etc/fluent/fluentd.conf` as follows:
 

--- a/how-to-guides/http-to-hdfs.md
+++ b/how-to-guides/http-to-hdfs.md
@@ -41,7 +41,7 @@ NOTE: CDH (Cloudera Distributed Hadoop) was discontinued. Superseded by Cloudera
 
 If `out_webhdfs` (fluent-plugin-webhdfs) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-webhdfs on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-webhdfs on your environment.
 
 {% hint style='info' %}
 If you use `fluent-package`, out_webhdfs (fluent-plugin-webhdfs) is bundled by default.

--- a/how-to-guides/http-to-td.md
+++ b/how-to-guides/http-to-td.md
@@ -35,7 +35,7 @@ You can install Fluentd via major packaging systems.
 
 If `out_td` (fluent-plugin-td) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section how to install fluent-plugin-td on your environment.
+See [Plugin Management](../installation/post-installation-guide#plugin-management) section for how to install fluent-plugin-td on your environment.
 
 {% hint style='info' %}
 If you use `fluent-package`, out_td (fluent-plugin-td) is bundled by default.
@@ -109,7 +109,7 @@ $ td tables
 +----------+------------+------+-------+--------+
 ```
 
-You can now issues queries against the imported data:
+You can now issue queries against the imported data:
 
 ```text
 $ td query -w -d testdb \

--- a/how-to-guides/kinesis-stream.md
+++ b/how-to-guides/kinesis-stream.md
@@ -40,7 +40,7 @@ You can install Fluentd via major packaging systems.
 
 If `out_kinesis_streams` (fluent-plugin-kinesis) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-kinesis on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-kinesis on your environment.
 
 ## Configuration
 

--- a/how-to-guides/logs-to-sematext.md
+++ b/how-to-guides/logs-to-sematext.md
@@ -30,7 +30,7 @@ You need to [sign up](https://apps.sematext.com/ui/registration) and create an A
 
 If [`out_elasticsearch`](../output/elasticsearch.md) (fluent-plugin-elasticsearch) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-elasticsearch on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-elasticsearch on your environment.
 
 Now you'll configure the `fluent-package` \(Fluentd\) to interface properly with Elasticsearch. Please edit `/etc/fluent/fluentd.conf` as shown below:
 

--- a/how-to-guides/parse-syslog.md
+++ b/how-to-guides/parse-syslog.md
@@ -75,7 +75,7 @@ by admin(uid=0)"}
 
 For security reasons, it is worth knowing which user performed what using `sudo`. In order to do so, we need to parse the message field. In other words, we need to extract `syslog` messages from `sudo` and handle them differently.
 
-For this purpose, we can use the [`grep`](../filter/grep.md) filter plugin. It examines the fields of events, and filter them based on regular expression patterns. In the following example, Fluentd filters out events that come from `sudo` and contain command data:
+For this purpose, we can use the [`grep`](../filter/grep.md) filter plugin. It examines the fields of events, and filters them based on regular expression patterns. In the following example, Fluentd filters out events that come from `sudo` and contain command data:
 
 ```text
 <source>
@@ -146,7 +146,7 @@ Then restart `fluentd`:
 $ sudo systemctl restart fluentd
 ```
 
-Let's execute some comment with `sudo`:
+Let's execute some command with `sudo`:
 
 ```text
 $ sudo cat /var/log/auth.log

--- a/how-to-guides/splunk-like-grep-and-alert-email.md
+++ b/how-to-guides/splunk-like-grep-and-alert-email.md
@@ -20,9 +20,9 @@ You can install Fluentd via major packaging systems.
 
 ### Install Grep Counter/Mail Plugin
 
-If `out_grepcounter` (fluent-plugin-grepcounter) and `out_mail` (fluent-plugin-mail) are not installed yet, please install it manually.
+If `out_grepcounter` (fluent-plugin-grepcounter) and `out_mail` (fluent-plugin-mail) are not installed yet, please install them manually.
 
-See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-mongo on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-mongo on your environment.
 
 ## Configuration
 
@@ -88,7 +88,7 @@ The configuration above consists of three main parts:
 
 1. The first `<source>` block sets the `httpd` log file as an event source for the daemon.
 2. The second `<match>` block tells Fluentd to count the number of 5xx responses per time window \(3 seconds\). If the number exceeds \(or is equal to\) the given threshold, Fluentd will emit an event with the tag `error_5xx.apache.access`.
-3. The third `<match>` block accepts events with the tag `error_5xx.apache.access`, and send an email to `alert@example.com` per event.
+3. The third `<match>` block accepts events with the tag `error_5xx.apache.access`, and sends an email to `alert@example.com` per event.
 
 In this way, fluentd now works as an email alerting system that monitors the web service for you.
 

--- a/how-to-guides/stream-analytics-with-materialize.md
+++ b/how-to-guides/stream-analytics-with-materialize.md
@@ -18,7 +18,7 @@ Fluentd and Fluent bit are vendor-neutral open-source log and metric collectors 
 
 ![](https://lh5.googleusercontent.com/4n8paH_K5rkJHtcn9l8PhBpI9c6vyPKJxO19KIwxDs1vsFtonfGfQbypcoDlhEBG3y7JrTooVtmJol9DdQgQfb2vR_mS589c0wQDlgEhfsrGjv4UCWDEDneRmrAj79pXpJqzv-o)
 
-If you’d like to start playing with this, here are step-by-step instructions to get setup in 15 minutes or less:
+If you’d like to start playing with this, here are step-by-step instructions to get set up in 15 minutes or less:
 
 1. [Install FluentBit](https://docs.fluentbit.io/manual/installation/getting-started-with-fluent-bit) or [Fluentd](https://docs.fluentd.org/installation) and use any of the many input plugins to read from Syslog, Network data, Kubernetes, Docker containers, Application log files, and more 
 2. Leverage Fluent Bit or Fluentd’s ability to write to JSON with the following output configurations

--- a/how-to-guides/syslog-influxdb.md
+++ b/how-to-guides/syslog-influxdb.md
@@ -34,7 +34,7 @@ Then, run the initial setup process and create/configure the following:
 * Create proper operation token
 * Set `fluent` organization
 * Create `test` bucket
-* Crete access API token
+* Create access API token
 
 See [Set up InfluxDB](https://docs.influxdata.com/influxdb/v2/get-started/setup/).
 
@@ -62,10 +62,10 @@ Next, install the InfluxDB output plugin:
 
 If [`out_influxdb`](https://github.com/influxdata/influxdb-plugin-fluent) (fluent-plugin-influxdb-v2) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section how to install fluent-plugin-influxdb-v2 on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-influxdb-v2 on your environment.
 
 {% hint style='warning' %}
-Do not install fluent-plugin-influxdb, it does not support for InfluxDB v2.
+Do not install fluent-plugin-influxdb, it does not support InfluxDB v2.
 {% endhint %}
 
 Finally, configure `/etc/fluent/fluentd.conf` as follows:

--- a/input/exec.md
+++ b/input/exec.md
@@ -94,13 +94,13 @@ Control target IO:
 | :--- | :--- | :--- |
 | false | false | 0.14.9 |
 
-Refer these for more details about `parse` section:
+Refer to these for more details about `parse` section:
 
 * [Parser Plugin Overview](../parser/)
 * [Parse Section Configuration](../configuration/parse-section.md)
 
 If you specify `format` in `<source>`, there is a case that `<parse>` section could be omitted.
-But that is deprecated v0.12 compatible notation, recommend to specify `<parse>` section explicitly.
+But that is deprecated v0.12 compatible notation. We recommend specifying `<parse>` section explicitly.
 
 #### `@type`
 

--- a/input/forward.md
+++ b/input/forward.md
@@ -337,7 +337,7 @@ The array of usernames.
 
 ## Protocol
 
-This plugin accepts both JSON or [MessagePack](http://msgpack.org/) messages and automatically detects which one is used. Internally, Fluentd uses MessagePack as it is more efficient than JSON.
+This plugin accepts both JSON and [MessagePack](http://msgpack.org/) messages and automatically detects which one is used. Internally, Fluentd uses MessagePack as it is more efficient than JSON.
 
 The time value is an `EventTime` or a platform-specific integer and is based on the output of Ruby's `Time.now.to_i` function. On Linux, BSD, and Mac systems, this is the number of seconds since 1970.
 
@@ -441,7 +441,7 @@ $ openssl s_client -connect localhost:24224 \
 
 If the connection gets established successfully, your setup is working fine.
 
-+For `fluentd` and `fluent-bit` combination, see Banzai Cloud article: [Secure logging on Kubernetes with Fluentd and Fluent Bit](https://banzaicloud.com/blog/k8s-logging-tls/).
+For `fluentd` and `fluent-bit` combination, see Banzai Cloud article: [Secure logging on Kubernetes with Fluentd and Fluent Bit](https://banzaicloud.com/blog/k8s-logging-tls/).
 
 ### How to Enable Password Authentication
 

--- a/input/http.md
+++ b/input/http.md
@@ -438,7 +438,7 @@ curl -X POST -F 'json={"message":"foo+bar"}' http://localhost:9880/app.log
 
 ### How to Enable TLS Encryption?
 
-Since v1.5.0, `in_http` support TLS transport. Here is a configuration example with HTTPS client:
+Since v1.5.0, `in_http` supports TLS transport. Here is a configuration example with HTTPS client:
 
 ```text
 <source>

--- a/input/monitor_agent.md
+++ b/input/monitor_agent.md
@@ -14,7 +14,7 @@ It is included in Fluentd's core.
 </source>
 ```
 
-This configuration launches HTTP server with 24220 port and get metrics:
+This configuration launches HTTP server with 24220 port and gets metrics:
 
 ```text
 $ curl http://host:24220/api/plugins.json
@@ -224,7 +224,7 @@ Here is the response:
 }
 ```
 
-`steps` field in `retry` show the number of flush failures, so next is the third try. `retry_count` is the total number of flush failures. This value is cleared when `fluentd` restarts, not when retry succeeds.
+`steps` field in `retry` shows the number of flush failures, so next is the third try. `retry_count` is the total number of flush failures. This value is cleared when `fluentd` restarts, not when retry succeeds.
 
 ## Tips and Tricks
 
@@ -242,7 +242,7 @@ The following list shows the available query parameters:
 | :--- | :--- | :--- |
 | `debug` | Constant | Expose additional internal metrics. Requires `include_debug_info true` |
 | `with_ivars` | Variable names | Expose the specified instance variables of each plugin. Requires `include_debug_info true` |
-| `tag` | Event tag | Only show plugins that matches the specified tag |
+| `tag` | Event tag | Only show plugins that match the specified tag |
 | `@id` | Plugin id | Filter plugins by plugin id |
 | `@type` | Plugin type | Filter plugins by plugin type |
 

--- a/input/syslog.md
+++ b/input/syslog.md
@@ -318,7 +318,7 @@ If your syslog uses octet counting mode, set `frame_type octet_count` in `in_sys
 
 ### How to Enable TLS Encryption
 
-Since v1.5.0, `in_syslog` support TLS transport. Here is the configuration example with `rsyslog`:
+Since v1.5.0, `in_syslog` supports TLS transport. Here is the configuration example with `rsyslog`:
 
 * `in_syslog`
 
@@ -370,7 +370,7 @@ With this configuration, 3 workers share 5140 port. No need of an additional por
 
 First, check your message format follows RFC3164/RFC5424 or not. Some systems say RFC3164/RFC5424 but it sends non-RFC3164/RFC5424 message, e.g. invalid priority, different timestamp, lack/add fields.
 
-If only timestamp is different, configure `time_format` in `<parse>` may help.
+If only timestamp is different, configuring `time_format` in `<parse>` may help.
 
 If other parts are different, the `syslog` parser cannot parse your message. To resolve the problem, there are several approaches:
 

--- a/input/tail.md
+++ b/input/tail.md
@@ -555,7 +555,7 @@ This parameter does not fit the typical application log use cases, so check your
 
 `in_tail` stops reading the new lines and pos file updates until `BufferOverflowError` is resolved. After resolving `BufferOverflowError`, resume emitting new lines and pos file updates.
 
-### `in_tail` is sometimes stopped when monitor lots of files. How to avoid it?
+### `in_tail` is sometimes stopped when monitoring lots of files. How to avoid it?
 
 Try to set `enable_stat_watcher false` in `in_tail` setting. We got several reports that `in_tail` is stopped when `*` is included in `path`, and the problem is resolved by disabling the `inotify` events.
 

--- a/input/windows_eventlog.md
+++ b/input/windows_eventlog.md
@@ -4,7 +4,7 @@ The `in_windows_eventlog` Input plugin allows Fluentd to read events from the Wi
 
 {% hint style='warning' %}
 This document doesn't describe all/most of parameters. For details, refer to the **Further Reading** section.
-If you afford to improve this article, please send pull request to https://github.com/fluent/fluentd-docs-gitbook
+If you can afford to improve this article, please send a pull request to https://github.com/fluent/fluentd-docs-gitbook
 {% endhint %}
 
 ## Installation

--- a/installation/before-install.md
+++ b/installation/before-install.md
@@ -61,9 +61,9 @@ These kernel options were originally taken from the presentation [How Netflix Tu
 
 ## Use sticky bit symlink/hardlink protection
 
-**NOTE:** CentOS 7 or later, Ubuntu 18.04 \(bionic\) or later, and Debian GNU/Linux 10 \(buster\) or later are supported these parameters.
+**NOTE:** CentOS 7 or later, Ubuntu 18.04 \(bionic\) or later, and Debian GNU/Linux 10 \(buster\) or later support these parameters.
 
-Fluentd sometimes uses predictable paths for dumping, writing files, and so on. This default settings for the protections are in `/etc/sysctl.d/10-link-restrictions.conf`, or `/usr/lib/sysctl.d/50-default.conf` or elsewhere.
+Fluentd sometimes uses predictable paths for dumping, writing files, and so on. These default settings for the protections are in `/etc/sysctl.d/10-link-restrictions.conf`, or `/usr/lib/sysctl.d/50-default.conf` or elsewhere.
 
 For symlink attack protection, check the following parameters are set to `1`:
 
@@ -72,7 +72,7 @@ fs.protected_hardlinks = 1
 fs.protected_symlinks = 1
 ```
 
-This settings are almost enough for time-of-check to time-of-use (TOCTOU, TOCTTOU or TOC/TOU) which are a class of software bugs.
+These settings are almost enough for time-of-check to time-of-use (TOCTOU, TOCTTOU or TOC/TOU) which is a class of software bugs.
 
 If you turned off these protections, please turn them on.
 

--- a/installation/install-by-deb-td-agent-v3.md
+++ b/installation/install-by-deb-td-agent-v3.md
@@ -14,7 +14,7 @@ That is why [Treasure Data, Inc](http://www.treasuredata.com/) provides **the st
 This article contains deprecated td-agent (EOL) information: SHOULD NOT use td-agent anymore.
 
 * As [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), recommend to [Upgrade td-agent from v3 to v4](https://www.fluentd.org/blog/upgrade-td-agent-v3-to-v4).
-* Do not directly upgrade from v3 to fluent-package v5. Such a workflow is not supported. It causes a trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
+* Do not directly upgrade from v3 to fluent-package v5. Such a workflow is not supported. It causes trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
 * Package archive was migrated from [packages.treasuredata.com](https://packages.treasuredata.com) to [fluentd.cdn.cncf.io](https://fluentd.cdn.cncf.io/index.html). Need to migrate URI in treasure-data.list by yourself or just disable it.
 {% endhint %}
 

--- a/installation/install-by-deb-td-agent-v4.md
+++ b/installation/install-by-deb-td-agent-v4.md
@@ -8,7 +8,7 @@ Fluentd is written in Ruby for flexibility, with performance-sensitive parts in 
 
 That is why [Treasure Data, Inc](http://www.treasuredata.com/) provides **the stable distribution of Fluentd**, called `td-agent`. The differences between Fluentd and `td-agent` can be found [here](https://www.fluentd.org/faqs).
 
-This installation guide is for `td-agent` v4. `td-agent` v4 use fluentd v1 in the core. See [this page](../quickstart/td-agent-v2-vs-v3-vs-v4.md) for the comparison and supported OS.
+This installation guide is for `td-agent` v4. `td-agent` v4 uses fluentd v1 in the core. See [this page](../quickstart/td-agent-v2-vs-v3-vs-v4.md) for the comparison and supported OS.
 
 ## Installing `td-agent`
 

--- a/installation/install-by-dmg-td-agent-v3.md
+++ b/installation/install-by-dmg-td-agent-v3.md
@@ -13,7 +13,7 @@ That is why [Treasure Data, Inc](http://www.treasuredata.com/) provides **the st
 {% hint style='danger' %}
 This article contains deprecated td-agent (EOL) information: SHOULD NOT use td-agent anymore.
 
-* `fluent-package` (successor of `td-agent`) for macOS is not be shipped yet, we plan to migrate to homebrew ecosystem in the future.
+* `fluent-package` (successor of `td-agent`) for macOS is not shipped yet, we plan to migrate to homebrew ecosystem in the future.
 * Package archive was migrated from [packages.treasuredata.com](https://packages.treasuredata.com) to [fluentd.cdn.cncf.io](https://fluentd.cdn.cncf.io/index.html).
 {% endhint %}
 

--- a/installation/install-by-dmg-td-agent-v4.md
+++ b/installation/install-by-dmg-td-agent-v4.md
@@ -8,14 +8,14 @@ Fluentd is written in Ruby for flexibility, with performance-sensitive parts in 
 
 That is why [Treasure Data, Inc](http://www.treasuredata.com/) provides **the stable distribution of Fluentd**, called `td-agent`. The differences between Fluentd and `td-agent` can be found [here](https://www.fluentd.org/faqs).
 
-For macOS, `td-agent` is distributed as `.dmg` installer.
+For macOS, `td-agent` is distributed as a `.dmg` installer.
 
 ## Step 1: Install `td-agent`
 
 {% hint style='danger' %}
 This article contains deprecated td-agent (EOL) information: SHOULD NOT use td-agent anymore.
 
-* `fluent-package` (successor of `td-agent`) for macOS is not be shipped yet, we plan to migrate to homebrew ecosystem in the future.
+* `fluent-package` (successor of `td-agent`) for macOS is not shipped yet, we plan to migrate to homebrew ecosystem in the future.
 * Package archive was migrated from [packages.treasuredata.com](https://packages.treasuredata.com) to [fluentd.cdn.cncf.io](https://fluentd.cdn.cncf.io/index.html).
 {% endhint %}
 

--- a/installation/install-by-msi-td-agent-v3.md
+++ b/installation/install-by-msi-td-agent-v3.md
@@ -21,7 +21,7 @@ Currently two versions of `td-agent` are available.
 This article contains deprecated td-agent (EOL) information: SHOULD NOT use td-agent anymore.
 
 * As [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), recommend to [Upgrade td-agent from v3 to v4](https://www.fluentd.org/blog/upgrade-td-agent-v3-to-v4).
-* Do not directly upgrade from v3 to fluent-package v5. Such a workflow is not supported. It causes a trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
+* Do not directly upgrade from v3 to fluent-package v5. Such a workflow is not supported. It causes trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
 * Package archive was migrated from [packages.treasuredata.com](https://packages.treasuredata.com) to [fluentd.cdn.cncf.io](https://fluentd.cdn.cncf.io/index.html).
 {% endhint %}
 

--- a/installation/install-by-rpm-td-agent-v3.md
+++ b/installation/install-by-rpm-td-agent-v3.md
@@ -8,13 +8,13 @@ Fluentd is written in Ruby for flexibility, with performance-sensitive parts in 
 
 That is why [Treasure Data, Inc](http://www.treasuredata.com/) provides **the stable distribution of Fluentd**, called `td-agent`. The differences between Fluentd and `td-agent` can be found [here](https://www.fluentd.org/faqs).
 
-## Using to install `td-agent`
+## How to install `td-agent`
 
 {% hint style='danger' %}
 This article contains deprecated td-agent (EOL) information: SHOULD NOT use td-agent anymore.
 
 * As [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), recommend to [Upgrade td-agent from v3 to v4](https://www.fluentd.org/blog/upgrade-td-agent-v3-to-v4).
-* Do not directly upgrade from v3 to fluent-package v5. Such a workflow is not supported. It causes a trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
+* Do not directly upgrade from v3 to fluent-package v5. Such a workflow is not supported. It causes trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
 * Package archive was migrated from [packages.treasuredata.com](https://packages.treasuredata.com) to [fluentd.cdn.cncf.io](https://fluentd.cdn.cncf.io/index.html). Need to migrate `baseurl` in td.repo by yourself or just disable it.
 {% endhint %}
 

--- a/installation/install-by-rpm-td-agent-v4.md
+++ b/installation/install-by-rpm-td-agent-v4.md
@@ -8,9 +8,9 @@ Fluentd is written in Ruby for flexibility, with performance-sensitive parts in 
 
 That is why [Treasure Data, Inc](http://www.treasuredata.com/) provides **the stable distribution of Fluentd**, called `td-agent`. The differences between Fluentd and `td-agent` can be found [here](https://www.fluentd.org/faqs).
 
-This installation guide is for `td-agent` v4. `td-agent` v4 use fluentd v1 in the core. See [this page](../quickstart/td-agent-v2-vs-v3-vs-v4.md) for the comparison and supported OS.
+This installation guide is for `td-agent` v4. `td-agent` v4 uses fluentd v1 in the core. See [this page](../quickstart/td-agent-v2-vs-v3-vs-v4.md) for the comparison and supported OS.
 
-## Using to install `td-agent`
+## How to install `td-agent`
 
 {% hint style='danger' %}
 This article contains deprecated td-agent (EOL) information: SHOULD NOT use td-agent anymore.

--- a/installation/install-calyptia-fluentd/install-by-dmg-calyptia-fluentd.md
+++ b/installation/install-calyptia-fluentd/install-by-dmg-calyptia-fluentd.md
@@ -8,7 +8,7 @@ Fluentd is written in Ruby for flexibility, with performance-sensitive parts in 
 
 That is why Chronosphere (formerly Calyptia) provides **the alternative stable distribution of Fluentd**, called `calyptia-fluentd`.
 
-For macOS, `td-agent` is distributed as `.dmg` installer.
+For macOS, `td-agent` is distributed as a `.dmg` installer.
 
 ## How to install `calyptia-fluentd`
 

--- a/installation/install-calyptia-fluentd/install-by-msi-calyptia-fluentd.md
+++ b/installation/install-calyptia-fluentd/install-by-msi-calyptia-fluentd.md
@@ -4,9 +4,9 @@
 
 `calyptia-fluentd` is the alternative distribution of Fluentd.
 
-* Includes Ruby and other library dependencies \(since most Windows box are not installed\).
+* Includes Ruby and other library dependencies \(since most Windows boxes are not installed\).
 * Includes a set of frequently-used 3rd party plugins such as `out_elasticsearch` and `in_windows_eventlog2`.
-* This alternative agent is developed by [Chronosphere](https://chronosphere.io) after its acuisition of Calyptia.
+* This alternative agent is developed by [Chronosphere](https://chronosphere.io) after its acquisition of Calyptia.
 
 Currently, calyptia-fluentd is on v1 only.
 
@@ -20,7 +20,7 @@ Download the latest MSI installer from [the download page](https://calyptia-flue
 
 ![calyptia-fluentd installation wizard](../.gitbook/assets/calyptia-fluentd1-wizard.png)
 
-**Note:** Calyptia-Fluentd is a drop-in-replacement agent of other Fluentd stable distribution. Currently, we use the same Windows Service name which is `fluentdwinsvc`. This is because when you already installed other agent which register Windows Service as `fluentdwinsvc`, you must uninstall already installed Windows Service which uses `fluentdwinsvc` as service name.
+**Note:** Calyptia-Fluentd is a drop-in-replacement agent of other Fluentd stable distribution. Currently, we use the same Windows Service name which is `fluentdwinsvc`. This is because when you already installed other agent which registers Windows Service as `fluentdwinsvc`, you must uninstall already installed Windows Service which uses `fluentdwinsvc` as service name.
 
 ### Step 2: Set up `calyptia-fluentd.conf`
 
@@ -88,7 +88,7 @@ PS> Start-Service fluentdwinsvc
 
 Note that using `fluentdwinsvc` is needed to start Fluentd service from the command-line. `fluentdwinsvc` is the service name and it should be passed to `net.exe` or `Start-Service` Cmdlet.
 
-The log file will be located at `C:/opt/calyptia-fluentd/calyptia-fleuntd.log` as we specified in Step 3.
+The log file will be located at `C:/opt/calyptia-fluentd/calyptia-fluentd.log` as we specified in Step 3.
 
 ### Step 6: Install Plugins
 

--- a/installation/install-fluent-package/install-by-deb-fluent-package-v5.md
+++ b/installation/install-fluent-package/install-by-deb-fluent-package-v5.md
@@ -12,7 +12,7 @@ Please see [fluent-package-v5-vs-td-agent](../../quickstart/fluent-package-v5-vs
 NOTE:
 
 * If you upgrade from `td-agent` v4, See [Upgrade to fluent-package v5](https://www.fluentd.org/blog/upgrade-td-agent-v4-to-v5).
-* Do not directly upgrade from v3 to v5. Such a workflow is not supported. It causes a trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
+* Do not directly upgrade from v3 to v5. Such a workflow is not supported. It causes trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
 {% endhint %}
 
 {% hint style='danger' %}

--- a/installation/install-fluent-package/install-by-deb-fluent-package.md
+++ b/installation/install-fluent-package/install-by-deb-fluent-package.md
@@ -11,9 +11,9 @@ Please see [fluent-package-v5-vs-td-agent](../../quickstart/fluent-package-v5-vs
 {% hint style='info' %}
 NOTE:
 
-* `fluent-package` will be shipped in two flavors - normal release version and LTS (Long Term Support) version. See [Scheduled support lifecycle announcement about Fluent Package v6](https://www.fluentd.org/blog/fluent-package-v6-scheduled-lifecycle) about difference between this two flavors.
+* `fluent-package` will be shipped in two flavors - normal release version and LTS (Long Term Support) version. See [Scheduled support lifecycle announcement about Fluent Package v6](https://www.fluentd.org/blog/fluent-package-v6-scheduled-lifecycle) about difference between these two flavors.
 * If you upgrade from `td-agent` v4, See [Upgrade to fluent-package v5](https://www.fluentd.org/blog/upgrade-td-agent-v4-to-v5).
-* Do not directly upgrade from v4 to v6. Such a workflow is not supported. It causes a trouble. Upgrade in stages. (v4 to v5, then v5 to v6)
+* Do not directly upgrade from v4 to v6. Such a workflow is not supported. It causes trouble. Upgrade in stages. (v4 to v5, then v5 to v6)
 {% endhint %}
 
 {% hint style='danger' %}

--- a/installation/install-fluent-package/install-by-dmg-fluent-package.md
+++ b/installation/install-fluent-package/install-by-dmg-fluent-package.md
@@ -11,7 +11,7 @@ Please see [fluent-package-v5-vs-td-agent](../../quickstart/fluent-package-v5-vs
 {% hint style='info' %}
 NOTE:
 
-* `fluent-package` is not be shipped yet, we plan to migrate to homebrew ecosystem in the future.
+* `fluent-package` is not shipped yet, we plan to migrate to homebrew ecosystem in the future.
 {% endhint %}
 
 {% hint style='danger' %}

--- a/installation/install-fluent-package/install-by-msi-fluent-package-v5.md
+++ b/installation/install-fluent-package/install-by-msi-fluent-package-v5.md
@@ -19,7 +19,7 @@ The following are deprecated fluent-package and td-agent (EOL) information:
 * As [Drop schedule announcement about EOL of Fluent Package v5](https://www.fluentd.org/blog/schedule-for-fluent-package-5-eol), recommend to upgrade to Fluent Package v6. See [Upgrade Guide for fluent-package v6](https://www.fluentd.org/blog/upgrade-guide-for-fluent-package-v6).
 * About deprecated [Treasure Agent (td-agent) v4 (EOL)](https://www.fluentd.org/blog/schedule-for-td-agent-4-eol), see [Install by .msi Installer v4 (Windows)](../install-by-msi-td-agent-v4.md).
 * About deprecated [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), see [Install by msi Package  v3](../install-by-msi-td-agent-v3.md).
-* Do not directly upgrade from v3 to v5. Such a workflow is not supported. It causes a trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
+* Do not directly upgrade from v3 to v5. Such a workflow is not supported. It causes trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
 {% endhint %}
 
 ### Step 1: Install `fluent-package`
@@ -75,12 +75,12 @@ Now `fluentd` starts listening to Windows Eventlog, and will print records to st
 ### Step 5: Run `fluentd` as Windows service
 
 Fluentd is registered as a Windows service permanently by the msi installer.
-Since version 5.0.0, the service does not automatically start after installed. You must manually start it.
+Since version 5.0.0, the service does not automatically start after installation. You must manually start it.
 
-Choose one of your preferred way:
+Choose one of your preferred ways:
 
 * Using GUI
-* Using `net.ext`
+* Using `net.exe`
 * Using Powershell Cmdlet
 
 #### Using GUI

--- a/installation/install-fluent-package/install-by-msi-fluent-package.md
+++ b/installation/install-fluent-package/install-by-msi-fluent-package.md
@@ -19,7 +19,7 @@ The following are deprecated (EOL) fluent-package and td-agent information:
 * About [Fluent Package (fluent-package) v5 (EOL)](https://www.fluentd.org/blog/schedule-for-fluent-package-5-eol), See [Install by .msi Package v5](./install-by-msi-fluent-package-v5.md).
 * About deprecated [Treasure Agent (td-agent) v4 (EOL)](https://www.fluentd.org/blog/schedule-for-td-agent-4-eol), see [Install by .msi Installer v4 (Windows)](../install-by-msi-td-agent-v4.md).
 * About deprecated [Treasure Agent (td-agent) 3 will not be maintained anymore](https://www.fluentd.org/blog/schedule-for-td-agent-3-eol), see [Install by msi Package  v3](../install-by-msi-td-agent-v3.md).
-* Do not directly upgrade from v3 to v5. Such a workflow is not supported. It causes a trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
+* Do not directly upgrade from v3 to v5. Such a workflow is not supported. It causes trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
 {% endhint %}
 
 ### Step 1: Install `fluent-package`
@@ -77,12 +77,12 @@ Now `fluentd` starts listening to Windows Eventlog, and will print records to st
 ### Step 5: Run `fluentd` as Windows service
 
 Fluentd is registered as a Windows service permanently by the msi installer.
-Since version 5.0.0, the service does not automatically start after installed. You must manually start it.
+Since version 5.0.0, the service does not automatically start after installation. You must manually start it.
 
-Choose one of your preferred way:
+Choose one of your preferred ways:
 
 * Using GUI
-* Using `net.ext`
+* Using `net.exe`
 * Using Powershell Cmdlet
 
 #### Using GUI

--- a/installation/install-fluent-package/install-by-rpm-fluent-package-v5.md
+++ b/installation/install-fluent-package/install-by-rpm-fluent-package-v5.md
@@ -12,7 +12,7 @@ Please see [fluent-package-v5-vs-td-agent](../../quickstart/fluent-package-v5-vs
 NOTE:
 
 * If you upgrade from `td-agent` v4, See [Upgrade to fluent-package v5](https://www.fluentd.org/blog/upgrade-td-agent-v4-to-v5).
-* Do not directly upgrade from v3 to v5. Such a workflow is not supported. It causes a trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
+* Do not directly upgrade from v3 to v5. Such a workflow is not supported. It causes trouble. Upgrade in stages. (v3 to v4, then v4 to v5)
 {% endhint %}
 
 {% hint style='danger' %}

--- a/installation/install-fluent-package/install-by-rpm-fluent-package.md
+++ b/installation/install-fluent-package/install-by-rpm-fluent-package.md
@@ -11,9 +11,9 @@ Please see [fluent-package-v5-vs-td-agent](../../quickstart/fluent-package-v5-vs
 {% hint style='info' %}
 NOTE:
 
-* `fluent-package` will be shipped in two flavors - normal release version and LTS (Long Term Support) version. See [Scheduled support lifecycle announcement about Fluent Package v6](https://www.fluentd.org/blog/fluent-package-v6-scheduled-lifecycle) about difference between this two flavors.
+* `fluent-package` will be shipped in two flavors - normal release version and LTS (Long Term Support) version. See [Scheduled support lifecycle announcement about Fluent Package v6](https://www.fluentd.org/blog/fluent-package-v6-scheduled-lifecycle) about difference between these two flavors.
 * If you upgrade from `td-agent` v4, See [Upgrade to fluent-package v5](https://www.fluentd.org/blog/upgrade-td-agent-v4-to-v5).
-* Do not directly upgrade from v4 to v6. Such a workflow is not supported. It causes a trouble. Upgrade in stages. (v4 to v5, then v5 to v6)
+* Do not directly upgrade from v4 to v6. Such a workflow is not supported. It causes trouble. Upgrade in stages. (v4 to v5, then v5 to v6)
 {% endhint %}
 
 {% hint style='danger' %}

--- a/installation/post-installation-guide.md
+++ b/installation/post-installation-guide.md
@@ -1,6 +1,6 @@
 # Post Installation Guide
 
-This article discusses the post-installation steps for new Fluentd users assuming that Fluentd has been installed using the `fluent-package`, `td-agent` and `calyptia-fluentd` package.
+This article discusses the post-installation steps for new Fluentd users assuming that Fluentd has been installed using the `fluent-package`, `td-agent` and `calyptia-fluentd` packages.
 
 ## System Administration
 

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -20,7 +20,7 @@ Sometimes, the input/filter/output plugin needs to save its internal metrics in 
 
 ## How To Use
 
-On Fluentd core, metrics plugin will handled on `<metrics>` on `<system>` to set up easily.
+On Fluentd core, metrics plugin will be handled on `<metrics>` on `<system>` to set up easily.
 
 Here is an example with `metrics_local`:
 
@@ -51,7 +51,7 @@ And this `local` type plugin should be used by default.
 
 ## List of 3rd party metrics plugins
 
-NOTE: This 3rd party metrics plugin list does not fully covers all of them.
+NOTE: This 3rd party metrics plugin list does not fully cover all of them.
 
 * [fluent-plugin-metrics-cmetrics](https://github.com/chronosphereio/calyptia-fluent-plugin-metrics-cmetrics)
 

--- a/monitoring-fluentd/monitoring-prometheus.md
+++ b/monitoring-fluentd/monitoring-prometheus.md
@@ -2,7 +2,7 @@
 
 This article describes how to monitor Fluentd via [Prometheus](https://prometheus.io/).
 
-Since both Prometheus and Fluentd are under [CNCF \(Cloud Native Computing Foundation\)](https://www.cncf.io/), Fluentd project is recommending to use Prometheus by default to monitor Fluentd.
+Since both Prometheus and Fluentd are under [CNCF \(Cloud Native Computing Foundation\)](https://www.cncf.io/), the Fluentd project recommends using Prometheus by default to monitor Fluentd.
 
 ## Installation
 

--- a/monitoring-fluentd/overview.md
+++ b/monitoring-fluentd/overview.md
@@ -54,7 +54,7 @@ A debug port for local communication is recommended for troubleshooting. The fol
 You can attach the process using the `fluent-debug` command through `dRuby`.
 
 {% hint style='warning' %}
-Since v1.19.3 or later, the default value of `bind` parameter was changed from '0.0.0.0' to '127.0.0.1'. If you want to allow access from remote, change it manually to '0.0.0.0'. Be careful to do it by your own risk that because this debug feature has no access control and allow to execute any valid code.
+Since v1.19.3 or later, the default value of `bind` parameter was changed from '0.0.0.0' to '127.0.0.1'. If you want to allow access from remote, change it manually to '0.0.0.0'. Be careful to do it at your own risk because this debug feature has no access control and allows executing any valid code.
 {% endhint %}
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.

--- a/output/README.md
+++ b/output/README.md
@@ -18,7 +18,7 @@ This article gives an overview of the Output Plugin.
 
 Fluentd v1.0 output plugins have three \(3\) buffering and flushing modes:
 
-* **Non-Buffered** mode does not buffer data and write out results
+* **Non-Buffered** mode does not buffer data and writes out results
 
   immediately.
 
@@ -173,7 +173,7 @@ Supported modes:
 
 * `drop_oldest_chunk`
 
-  This mode drops the oldest chunks. This mode is useful for monitoring system destinations. For monitoring, newer events are important than older.
+  This mode drops the oldest chunks. This mode is useful for monitoring system destinations. For monitoring, newer events are more important than older.
 
 ### Control Retrying
 
@@ -254,7 +254,7 @@ For other configuration parameters available in `<buffer>` section, see [Buffer 
 
 ## Secondary Output
 
-In `buffered` mode, the user can specify `<secondary>` with any output plugin in `<match>` configuration. If plugins continue to fail writing buffer chunks and exceeds the timeout threshold for retries, then output plugins will delegate the writing of the buffer chunk to the secondary plugin.
+In `buffered` mode, the user can specify `<secondary>` with any output plugin in `<match>` configuration. If plugins continue to fail writing buffer chunks and exceed the timeout threshold for retries, then output plugins will delegate the writing of the buffer chunk to the secondary plugin.
 
 `<secondary>` is useful for backup when destination servers are unavailable, e.g. `forward`, `mongo`, etc. We strongly recommend `out_secondary_file` plugin for `<secondary>`.
 

--- a/output/buffer.md
+++ b/output/buffer.md
@@ -105,7 +105,7 @@ Overwrites the default value in this plugin.
 #### Common Buffer / Output parameters
 
 In addition, you can configure other common settings.
-Please see the followings for details.
+Please see the following for details.
 
 * [Buffer Section Configurations](../configuration/buffer-section.md)
 * [Buffer Plugin Overview](../buffer/)

--- a/output/elasticsearch.md
+++ b/output/elasticsearch.md
@@ -8,7 +8,7 @@ Records will be sent to Elasticsearch when the `chunk_keys` condition has been m
 
 {% hint style='warning' %}
 This document doesn't describe all/most of parameters. For details, refer to the **Further Reading** section.
-If you afford to improve this article, please send pull request to https://github.com/fluent/fluentd-docs-gitbook
+If you can afford to improve this article, please send a pull request to https://github.com/fluent/fluentd-docs-gitbook
 {% endhint %}
 
 ## Installation
@@ -57,7 +57,7 @@ The port number of your Elasticsearch node \(default: `9200`\).
 
 ### `hosts` \(optional\)
 
-If you want to connect to more than one Elasticsearch nodes, specify this option in the following format:
+If you want to connect to more than one Elasticsearch node, specify this option in the following format:
 
 ```text
 hosts host1:port1,host2:port2,host3:port3

--- a/output/exec_filter.md
+++ b/output/exec_filter.md
@@ -73,7 +73,7 @@ The command \(program\) to execute. The `out_exec_filter` plugin passes the inco
 
 The number of spawned processes for `command`.
 
-If the number is larger than 2, fluentd uses spawned processes by round robin fashion.
+If the number is larger than 2, fluentd uses spawned processes in a round robin fashion.
 
 ### `child_respawn`
 

--- a/output/forward.md
+++ b/output/forward.md
@@ -189,7 +189,7 @@ Use service discovery plugin instead of fixed `<server>` list. See also [Service
 | :--- | :--- | :--- |
 | bool | false | 0.14.0 |
 
-Changes the protocol to **at-least-once**. The plugin waits the ack from destination's `in_forward` plugin.
+Changes the protocol to **at-least-once**. The plugin waits for the ack from destination's `in_forward` plugin.
 
 ### `ack_response_timeout`
 
@@ -561,7 +561,7 @@ Valid logical store names are:
 * WEBHOSTING
 * REMOTE DESKTOP
 
-Logical store name is case-insensitive. Note that this section configurations work only for Windows.
+Logical store name is case-insensitive. Note that these section configurations work only for Windows.
 
 ```text
 <match debug.**>
@@ -595,7 +595,7 @@ If you are using a self-signed certificate, export the certificate file from Win
 </match>
 ```
 
-Note that these configuration works for root certificate which is put in Windows Certstore. Currently, the chained certificate is not supported.
+Note that this configuration works for root certificate which is put in Windows Certstore. Currently, the chained certificate is not supported.
 
 Certificate thumbprint is able to obtain with [`certutil`](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/certutil) command.
 

--- a/output/http.md
+++ b/output/http.md
@@ -115,7 +115,7 @@ The proxy for HTTP request.
 | :--- | :--- | :--- |
 | string | nil | 1.7.0 |
 
-`Content-Type` for HTTP request. `out_http` automatically set `Content-Type` for built-in formatters when this parameter is not specified.
+`Content-Type` for HTTP request. `out_http` automatically sets `Content-Type` for built-in formatters when this parameter is not specified.
 
 Here is a table:
 
@@ -132,7 +132,7 @@ Here is a table:
 | :--- | :--- | :--- |
 | bool | false | 1.10.4 |
 
-Using the array format of JSON. This parameter is used and valid only for json format. When `json_array` as true, Content-Type should be `application/json` and be able to use JSON data for the HTTP request body.
+Using the array format of JSON. This parameter is used and valid only for json format. When `json_array` is true, Content-Type should be `application/json` and be able to use JSON data for the HTTP request body.
 
 * `json_array true`
 
@@ -496,6 +496,6 @@ And, receiver `in_http` configuration should be:
 </source>
 ```
 
-But, we recommend to use in/out [`forward`](forward.md) plugin to communicate with two Fluentd instances due to `at-most-once` and `at-least-once` semantics for rigidity.
+But, we recommend using in/out [`forward`](forward.md) plugin to communicate with two Fluentd instances due to `at-most-once` and `at-least-once` semantics for rigidity.
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open article- source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.

--- a/output/kafka.md
+++ b/output/kafka.md
@@ -6,7 +6,7 @@ The `out_kafka2` Output plugin writes records into [Apache Kafka](https://kafka.
 
 {% hint style='warning' %}
 This document doesn't describe all/most of parameters. For details, refer to the **Further Reading** section.
-If you afford to improve this article, please send pull request to https://github.com/fluent/fluentd-docs-gitbook
+If you can afford to improve this article, please send a pull request to https://github.com/fluent/fluentd-docs-gitbook
 {% endhint %}
 
 ## Installation

--- a/output/mongo.md
+++ b/output/mongo.md
@@ -8,7 +8,7 @@ If you're using `ReplicaSet`, please see the [`out_mongo_replset`](mongo_replset
 
 {% hint style='warning' %}
 This document doesn't describe all/most of parameters. For details, refer to the **Further Reading** section.
-If you afford to improve this article, please send pull request to https://github.com/fluent/fluentd-docs-gitbook
+If you can afford to improve this article, please send a pull request to https://github.com/fluent/fluentd-docs-gitbook
 {% endhint %}
 
 ## Why Fluentd with MongoDB?

--- a/output/mongo_replset.md
+++ b/output/mongo_replset.md
@@ -6,11 +6,11 @@ The `out_mongo_replset` Output plugin writes records into [MongoDB](http://mongo
 
 This plugin is for users using ReplicaSet. If you are not using `ReplicaSet`, please see the [`out_mongo`](mongo.md) article instead.
 
-This plugin has breaking changes since 0.8.0 due to mongo-ruby driver's breaking changes. If you are using a prior 0.7.x series, please be careful to upgrade 1.0.0 or later versions.
+This plugin has breaking changes since 0.8.0 due to mongo-ruby driver's breaking changes. If you are using a prior 0.7.x series, please be careful to upgrade to 1.0.0 or later versions.
 
 {% hint style='warning' %}
 This document doesn't describe all/most of parameters. For details, refer to the **Further Reading** section.
-If you afford to improve this article, please send pull request to https://github.com/fluent/fluentd-docs-gitbook
+If you can afford to improve this article, please send a pull request to https://github.com/fluent/fluentd-docs-gitbook
 {% endhint %}
 
 ## Why Fluentd with MongoDB?

--- a/output/opensearch.md
+++ b/output/opensearch.md
@@ -6,7 +6,7 @@ Records will be sent to OpenSearch when the `chunk_keys` condition has been met.
 
 {% hint style='warning' %}
 This document doesn't describe all/most of parameters. For details, refer to the **Further Reading** section.
-If you afford to improve this article, please send pull request to https://github.com/fluent/fluentd-docs-gitbook
+If you can afford to improve this article, please send a pull request to https://github.com/fluent/fluentd-docs-gitbook
 {% endhint %}
 
 ## Installation
@@ -59,7 +59,7 @@ The port number of your OpenSearch node \(default: `9200`\).
 
 ### `hosts` \(optional\)
 
-If you want to connect to more than one OpenSearch nodes, specify this option in the following format:
+If you want to connect to more than one OpenSearch node, specify this option in the following format:
 
 ```text
 hosts host1:port1,host2:port2,host3:port3

--- a/output/rewrite_tag_filter.md
+++ b/output/rewrite_tag_filter.md
@@ -4,7 +4,7 @@ The `out_rewrite_tag_filter` Output plugin provides a rule-based mechanism for r
 
 {% hint style='warning' %}
 This document doesn't describe all/most of parameters. For details, refer to the **Further Reading** section.
-If you afford to improve this article, please send pull request to https://github.com/fluent/fluentd-docs-gitbook
+If you can afford to improve this article, please send a pull request to https://github.com/fluent/fluentd-docs-gitbook
 {% endhint %}
 
 ## How It Works
@@ -17,7 +17,7 @@ When a message is handled by the plugin, the rules are tested one by one in orde
 
 #### Basic Example
 
-This in an example of how to use this plugin to rewrite tags. In the example, records tagged with `app.component` will have their tag prefixed with the value of the key `message`:
+This is an example of how to use this plugin to rewrite tags. In the example, records tagged with `app.component` will have their tag prefixed with the value of the key `message`:
 
 ```text
 <match app.component>
@@ -98,7 +98,7 @@ For more details, see [Plugin Management](../deployment/plugin-management.md).
 
 ## Configuration Example
 
-By design, the configuration drops some pattern records first and then it re-emits the next matched record as the new tag name. The example configuration shown below gives an example on how the plugin can be used to define a number of rules that examine values from different keys and sets the tag depending on the regular expression configured in each rule.
+By design, the configuration drops some pattern records first and then it re-emits the next matched record as the new tag name. The example configuration shown below gives an example on how the plugin can be used to define a number of rules that examine values from different keys and set the tag depending on the regular expression configured in each rule.
 
 The tag value is later used to decide whether the log event shall be dropped or not.
 

--- a/output/s3.md
+++ b/output/s3.md
@@ -8,7 +8,7 @@ The file will be created when the `timekey` condition has been met. To change th
 
 {% hint style='warning' %}
 This document doesn't describe all/most of parameters. For details, refer to the **Further Reading** section.
-If you afford to improve this article, please send pull request to https://github.com/fluent/fluentd-docs-gitbook
+If you can afford to improve this article, please send a pull request to https://github.com/fluent/fluentd-docs-gitbook
 {% endhint %}
 
 ## Installation
@@ -151,7 +151,7 @@ For example, if:
 
 Then, `hello20141111_0.json` would be the example of an actual S3 path.
 
-This parameter is for advanced users. Most users should NOT modify it. Also, always make sure that `%{index}` appears in the customized `s3_object_key_format` \(Otherwise, multiple buffer flushes within the same time slice throws an error\).
+This parameter is for advanced users. Most users should NOT modify it. Also, always make sure that `%{index}` appears in the customized `s3_object_key_format` \(Otherwise, multiple buffer flushes within the same time slice throw an error\).
 
 ### `store_as`
 

--- a/output/secondary_file.md
+++ b/output/secondary_file.md
@@ -111,7 +111,7 @@ When `gzip` is specified, `.gz` is automatically added to the output file path a
 
 ## How to resend secondary file
 
-The secondary file can be resend by `fluent-cat` command.
+The secondary file can be resent by `fluent-cat` command.
 
 Here is the example to resend `dump.bin.0` to `127.0.0.1:24224` using `fluent-cat`.
 

--- a/output/webhdfs.md
+++ b/output/webhdfs.md
@@ -8,7 +8,7 @@ The file will be created when the `timekey` condition has been met. To change th
 
 {% hint style='warning' %}
 This document doesn't describe all/most of parameters. For details, refer to the **Further Reading** section.
-If you afford to improve this article, please send pull request to https://github.com/fluent/fluentd-docs-gitbook
+If you can afford to improve this article, please send a pull request to https://github.com/fluent/fluentd-docs-gitbook
 {% endhint %}
 
 ## Install
@@ -70,7 +70,7 @@ Please see the [Configuration File](../configuration/config-file.md) article for
 
 ### `@type` \(required\)
 
-The value must be `webhfds`.
+The value must be `webhdfs`.
 
 ### `host` \(required\)
 

--- a/parser/apache_error.md
+++ b/parser/apache_error.md
@@ -8,7 +8,7 @@ See [Parse Section Configurations](../configuration/parse-section.md).
 
 ## Regexp patterns
 
-This is regexp pattern of this plugin:
+This is the regexp pattern of this plugin:
 
 ```text
 expression /^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])? \[client (?<client>[^\]]*)\] (?<message>.*)$/

--- a/parser/syslog.md
+++ b/parser/syslog.md
@@ -30,7 +30,7 @@ Specifies the event time format for the RFC-5424 protocol.
 
 Specifies the protocol format. Supported values are `rfc3164`, `rfc5424` and `auto`. Default is `rfc3164`. If your `syslog` uses `rfc5424`, use `rfc5424` instead.
 
-`auto` is useful when this parser receives both `rfc3164` and `rfc5424` message. `syslog` parser detects message format by using message prefix.
+`auto` is useful when this parser receives both `rfc3164` and `rfc5424` messages. `syslog` parser detects message format by using message prefix.
 
 ### `with_priority`
 

--- a/plugin-development/README.md
+++ b/plugin-development/README.md
@@ -4,7 +4,7 @@
 
 With fluentd, you can install and create custom plugins.
 
-To install or create a custom plugin, the file name need to be `<TYPE>_<NAME>.rb`. Note that `TYPE` is a prefix indicating the type of plugin, and could be:
+To install or create a custom plugin, the file name needs to be `<TYPE>_<NAME>.rb`. Note that `TYPE` is a prefix indicating the type of plugin, and could be:
 
 | prefix | plugin type |
 | :---: | :---: |
@@ -65,7 +65,7 @@ end
 
 See the respective plugin development article, "How to write XXX plugin", for API details.
 
-A single Ruby script is easy to write but hard to test, manage, version. publish, etc.
+A single Ruby script is easy to write but hard to test, manage, version, publish, etc.
 
 If you want to publish a plugin under version control, you should use `bundle gem` to create the plugin source tree and then `git init` it. It requires the `bundler` gem in your Ruby environment.
 
@@ -167,7 +167,7 @@ The **copy** output plugin copies the matched events to the multiple output plug
 </match>
 ```
 
-You can use **stdout** filter instead of **copy** and **stdout** combination. The result is the same as above but more simpler.
+You can use **stdout** filter instead of **copy** and **stdout** combination. The result is the same as above but simpler.
 
 ```text
 <source>
@@ -193,7 +193,7 @@ Fluent::Test::Driver::Output  # Test driver for output plugins.
 Fluent::Test::Driver::Filter  # Test driver for filter plugins.
 ```
 
-It is strongly recommended to use `test-unit` as the unit test library. Fluentd's test drivers assume that the test code uses it. Add `test-unit`as the development dependency in your `gemspec`, add `Rake` task to run tests in your `Rakefile` and write test code in `test/plugin/test_in_my_awesome.rb`.
+It is strongly recommended to use `test-unit` as the unit test library. Fluentd's test drivers assume that the test code uses it. Add `test-unit` as the development dependency in your `gemspec`, add `Rake` task to run tests in your `Rakefile` and write test code in `test/plugin/test_in_my_awesome.rb`.
 
 **gemspec**
 
@@ -326,16 +326,16 @@ It is recommended to use the new v1 plugin API for writing new plugins.
 
 ### Send a patch or fork?
 
-If you have a problem with any existing plugins or a new feature idea, sending a patch is better. If the plugin author is non-active, try to become its new plugin maintainer first. Forking a plugin and release its alternative version, e.g. `fluent-plugin-xxx-alt` is considered the last option.
+If you have a problem with any existing plugins or a new feature idea, sending a patch is better. If the plugin author is non-active, try to become its new plugin maintainer first. Forking a plugin and releasing its alternative version, e.g. `fluent-plugin-xxx-alt` is considered the last option.
 
-### Be careful not breaking Fluentd's core functionality
+### Be careful not to break Fluentd's core functionality
 
 Any fluentd plugin can unknowingly break fluentd completely (and possibly break other plugins) by requiring some incompatible modules.
 
 One typical example is reloading `yajl/json_gem` from plugin. (`yajl/json_gem` compatibility layer is problematic, not for `yajl` itself)
 It breaks a functionality to parse Fluentd's configuration completely.
 
-Fluentd's plug-in mechanism has a merit to extend functionality, but plugin developer must be careful a possibility of breaking it.
+Fluentd's plug-in mechanism has a merit to extend functionality, but plugin developer must be careful about the possibility of breaking it.
 
 
 ## Further Reading

--- a/plugin-development/api-config-types.md
+++ b/plugin-development/api-config-types.md
@@ -340,7 +340,7 @@ key_values {"key1": "value1", "key2": "value2"} # written in JSON
 key_values key1:value1,key2:value2
 ```
 
-This configurations will be converted to:
+This configuration will be converted to:
 
 ```ruby
 { key1: "value1", key2: "value2" }

--- a/plugin-development/api-plugin-base.md
+++ b/plugin-development/api-plugin-base.md
@@ -134,7 +134,7 @@ Defines a section to construct structured \(nested\) configuration.
   * `param_name`: The section name.
   * `final`: If `true`, the subclass of this class cannot override this section.
 
-    For example, the third0party plugins cannot override the buffer section.
+    For example, the third-party plugins cannot override the buffer section.
 
   * `init`: If `true`, the parameters in this section must have default values.
 

--- a/plugin-development/api-plugin-filter.md
+++ b/plugin-development/api-plugin-filter.md
@@ -85,10 +85,10 @@ end
 
 #### `#filter_stream(tag, es)`
 
-This method implements the event stream based filtering logic. If you hard to implement the logic with `filter`, e.g. need to handle multiple records in one processing, use this method.
+This method implements the event stream based filtering logic. If you find it hard to implement the logic with `filter`, e.g. need to handle multiple records in one processing, use this method.
 
 * `tag`: is a `String`,
-* `es` is a `Fluent::EventStream` classes. See [EventStream code](https://github.com/fluent/fluentd/blob/master/lib/fluent/event.rb)
+* `es` is a `Fluent::EventStream` class. See [EventStream code](https://github.com/fluent/fluentd/blob/master/lib/fluent/event.rb)
 
 The return value of this method should be `MultiEventStream`. If it is `nil`, the event will be discarded.
 

--- a/plugin-development/api-plugin-input.md
+++ b/plugin-development/api-plugin-input.md
@@ -130,7 +130,7 @@ Then, the plugin will succeed with zero-downtime restart.
 
 ## Writing Tests
 
-Fluentd input plugin has one or more points to be tested. Others aspects \(parsing configurations, controlling buffers, retries, flushes, etc.\) are controlled by the Fluentd core.
+Fluentd input plugin has one or more points to be tested. Other aspects \(parsing configurations, controlling buffers, retries, flushes, etc.\) are controlled by the Fluentd core.
 
 Fluentd also provides the test drivers for plugins. You can write tests for your own plugins very easily:
 

--- a/plugin-development/api-plugin-output.md
+++ b/plugin-development/api-plugin-output.md
@@ -108,7 +108,7 @@ This mode is available when the `#process` method is implemented.
 
 ### Sync-Buffered Mode
 
-In this mode, the output plugin temporarily stores events in a buffer and send them later. The exact buffering behavior is fine-tunable through configuration parameters.
+In this mode, the output plugin temporarily stores events in a buffer and sends them later. The exact buffering behavior is fine-tunable through configuration parameters.
 
 The most notable benefit of this mode is that it enables you to leverage the native retry mechanism. The errors such as network failures are transparently handled by Fluentd and you do not need to implement an error-handling mechanism by yourself.
 
@@ -116,7 +116,7 @@ This mode is available when the `#write` method is implemented.
 
 ### Async-Buffered Mode
 
-In this mode, the output plugin temporarily stores events in a buffer and send them later. The major difference with the synchronous mode is that this mode allows you to defer the acknowledgment of transferred records. For example, you can implement the **at-least-once** semantics using this mode.
+In this mode, the output plugin temporarily stores events in a buffer and sends them later. The major difference with the synchronous mode is that this mode allows you to defer the acknowledgment of transferred records. For example, you can implement the **at-least-once** semantics using this mode.
 
 Please read "How To Use Asynchronous Buffered Mode" for details.
 
@@ -158,7 +158,7 @@ It is important to note that the methods that decide modes are called in `#start
 
 For more details, see [Buffer](../configuration/buffer-section.md) section.
 
-Fluentd creates buffer chunks to store events. Each buffer chunks should be written at once, without any re-chunking. In Fluentd v1.0, users can specify chunk keys by themselves using `<buffer CHUNK_KEYS>` section.
+Fluentd creates buffer chunks to store events. Each buffer chunk should be written at once, without any re-chunking. In Fluentd v1.0, users can specify chunk keys by themselves using `<buffer CHUNK_KEYS>` section.
 
 Example:
 
@@ -212,7 +212,7 @@ Buffer configuration provides `flush_mode` to control the mode. Here are its sup
 * `interval`: 1, 2 and 3 are enabled
 * `immediate`: 4 is enabled
 
-Default is `lazy` if `time` is specified as the chunk key, `interval` otherwise. If `flush_mode` is explicitly configured, the plugin used the configured mode.
+Default is `lazy` if `time` is specified as the chunk key, `interval` otherwise. If `flush_mode` is explicitly configured, the plugin uses the configured mode.
 
 ### How to Change the Default Values for Parameters
 
@@ -275,7 +275,7 @@ The serialization format to store events in a buffer may be customized by overri
 
 Generally, it is not needed. Fluentd has its own serialization format and there are many benefits to just use the default one. For example, it transparently allows you to iterate through records via `chunk.each`.
 
-An exceptional case is when the chunks need to sent to the destination without any further processing. For example, `out_file` overrides `#format` so that it can produce chunk files that exactly look like the final outputs. By doing this, `out_file` can flush data just by moving chunk files to the destination path.
+An exceptional case is when the chunks need to be sent to the destination without any further processing. For example, `out_file` overrides `#format` so that it can produce chunk files that exactly look like the final outputs. By doing this, `out_file` can flush data just by moving chunk files to the destination path.
 
 For further details, read the interface definition of the `#format` method below.
 
@@ -378,7 +378,7 @@ Return value is a `String`.
 
 ### `es.each(&block)`
 
-`EventStream#each` receives a block argument and call it for each event \(`time` and `record`\).
+`EventStream#each` receives a block argument and calls it for each event \(`time` and `record`\).
 
 Example:
 

--- a/plugin-development/api-plugin-parser.md
+++ b/plugin-development/api-plugin-parser.md
@@ -115,7 +115,7 @@ Parser plugins have a method to parse input \(text\) data to a structured record
 
 #### `#parse(text, &block)`
 
-It gets input data as `text`, and call `&block` to feed the results of the parser. The input `text` may contain two or more records so that means the parser plugin might call the `&block` two or more times for one argument.
+It gets input data as `text`, and calls `&block` to feed the results of the parser. The input `text` may contain two or more records so that means the parser plugin might call the `&block` two or more times for one argument.
 
 Parser plugins must implement this method.
 

--- a/plugin-development/plugin-test-code.md
+++ b/plugin-development/plugin-test-code.md
@@ -41,7 +41,7 @@ The recommended fluentd plugin project structure is:
 
 ## Plugin Test Driver Overview
 
-There are some useful Test Drivers for plugin testing. We can write test code for plugins as following:
+There are some useful Test Drivers for plugin testing. We can write test code for plugins as follows:
 
 ```ruby
 # Load the module that defines common initialization method (Required)
@@ -112,7 +112,7 @@ end
 
 ## Test Driver Base API
 
-The methods in this section are available for all Test Driver.
+The methods in this section are available for all Test Drivers.
 
 ### `initialize(klass, opts: {}, &block)`
 
@@ -480,7 +480,7 @@ d.filtered_records
 * `wait_flush_completion`: if `true`, waiting for `flush` to complete
 * `force_flush_retry`: if `true`, retrying flush forcibly
 
-Run Test Driver. This Test Driver will be stop running immediately after evaluating the `block` if given.
+Run Test Driver. This Test Driver will stop running immediately after evaluating the `block` if given.
 
 Otherwise, you must register conditions to stop running Test Driver.
 

--- a/plugin-development/plugin-update-from-v0.12.md
+++ b/plugin-development/plugin-update-from-v0.12.md
@@ -78,7 +78,7 @@ Add a Requirements section to `README.md` like this:
 | &gt;= 1.0.0 | &gt;= v1 | &gt;= 2.4 |
 | &lt; 1.0.0 | &gt;= v0.12.0 | &gt;= 2.1 |
 
-This helps that plugin users can understand plugin requirements.
+This helps plugin users understand plugin requirements.
 
 ### 6. Release New Version
 
@@ -468,7 +468,7 @@ For more details, see [Understanding Chunking and Metadata](api-plugin-output.md
 
 For the multi-output plugins \(sub-class of `Fluent::MultiOutput`\), there are many points to be considered.
 
-If the plugin uses `<store>` sections and instantiates plugins per each store section, use `Fluent::Plugin::MultiOutput`. See code to know how to use it: `lib/fluent/plugin/multi_output.rb` or some built-in plugins such as`out_copy` and `out_roundrobin`.
+If the plugin uses `<store>` sections and instantiates plugins per each store section, use `Fluent::Plugin::MultiOutput`. See code to know how to use it: `lib/fluent/plugin/multi_output.rb` or some built-in plugins such as `out_copy` and `out_roundrobin`.
 
 Otherwise, your plugin does something curious for Fluentd. Read code of `lib/fluent/plugin/output.rb` and `lib/fluent/plugin/bare_output.rb`, and consider which is better for your plugin. But, it is advised against using `Fluent::Plugin::BareOutput` for most use cases.
 

--- a/plugin-helper-overview/README.md
+++ b/plugin-helper-overview/README.md
@@ -12,7 +12,7 @@ Example:
 helpers :timer, :storage, :compat_parameters
 ```
 
-It will include `Timer`, `Storage`. and `CompatParameters` plugin helpers.
+It will include `Timer`, `Storage`, and `CompatParameters` plugin helpers.
 
 ## Built-in Plugin Helpers
 

--- a/plugin-helper-overview/api-plugin-helper-child_process.md
+++ b/plugin-helper-overview/api-plugin-helper-child_process.md
@@ -42,7 +42,7 @@ This method executes `child_process` with the given parameters and routine.
 * `parallel`: `true`/`false`. Default is `false`.
 * `mode`: \[`:read`, `:write`\]. Default is \[`:read`, `:write`\].
 * `stderr`: Connect stderr or not. Default is `:discard`.
-* `env`: Environment valuables. Default is {}.
+* `env`: Environment variables. Default is {}.
 * `unsetenv`: `true`/`false`. Default is `false`
 * `chdir`: Working directory. Default is `nil`.
 * `internal_encoding`: Internal character encoding. Default is `utf-8`.

--- a/plugin-helper-overview/api-plugin-helper-compat_parameters.md
+++ b/plugin-helper-overview/api-plugin-helper-compat_parameters.md
@@ -1,6 +1,6 @@
 # Plugin Helper: Compat Parameters
 
-`compat_parameters` helper convert parameters from v0.12 to v1.0 style.
+`compat_parameters` helper converts parameters from v0.12 to v1.0 style.
 
 Here is an example:
 

--- a/plugin-helper-overview/api-plugin-helper-service_discovery.md
+++ b/plugin-helper-overview/api-plugin-helper-service_discovery.md
@@ -49,7 +49,7 @@ Since v1.13.0, `discovery_manager` is almost automatically configured only by ca
 #### Parameters
 
 * `title`: Thread name. Must be unique. \(required\)
-* `static_default_service_directive`: The directive name of each service when "static" service discovery is enabled in default.
+* `static_default_service_directive`: The directive name of each service when "static" service discovery is enabled by default.
 * `load_balancer`: object which has two methods \#rebalance and \#select\_service.
 * `custom_build_method`: The custom method to build the service.
 * `interval`: Time interval for updating target service.
@@ -74,7 +74,7 @@ It manages service discovery functionalities such as updating target services an
 
 * [`out_forward`](../output/forward.md)
 
-## Migration guide from `service_discovery_create_manager` to more simpler helper method
+## Migration guide from `service_discovery_create_manager` to a simpler helper method
 
 Here is the guide to migrate to newer API which is available since v1.13.0.
 

--- a/plugin-helper-overview/api-plugin-helper-thread.md
+++ b/plugin-helper-overview/api-plugin-helper-thread.md
@@ -1,6 +1,6 @@
 # Plugin Helper: Thread
 
-The `thread` plugin helper manages threads and these threads are integrated with plugins. No need manual run or shutdown in the plugin.
+The `thread` plugin helper manages threads and these threads are integrated with plugins. No need for manual run or shutdown in the plugin.
 
 Here is an example:
 

--- a/plugins/input/dummy.md
+++ b/plugins/input/dummy.md
@@ -3,7 +3,7 @@
 `in_dummy` has been renamed `in_sample` since Fluentd v1.11.12.
 See [`sample` input plugin](/input/sample.md) article for more details.
 
-You can keep to use following configuration in v1:
+You can keep using the following configuration in v1:
 
 ```text
 <source>

--- a/quickstart/faq.md
+++ b/quickstart/faq.md
@@ -2,14 +2,14 @@
 
 ## Which version of Ruby does `fluentd` support?
 
-Latest fluentd works on Ruby 3.2 or later.
+The latest fluentd works on Ruby 3.2 or later.
 
-Though the minimum required version is Ruby 3.2 or later, we recommend using `fluentd` with more
+Though the minimum required version is Ruby 3.2 or later, we recommend using `fluentd` with a
 newer stable version.
 
-## What is the difference between v1 or v0.14?
+## What is the difference between v1 and v0.14?
 
-No difference. v1 is built on top of v0.14. Use v1 for a newer installation. We use v1 or v1.x on our document.
+No difference. v1 is built on top of v0.14. Use v1 for a newer installation. We use v1 or v1.x in our document.
 
 ## Operations
 
@@ -51,7 +51,7 @@ There are several reasons:
 
 If you get other errors, Google it.
 
-### fluentd raises `tzinfo` conflict error after installed plugins
+### fluentd raises `tzinfo` conflict error after installing plugins
 
 Fluentd supports tzinfo v1.1 or later and recent td-agent / fluent-package / official images install tzinfo v2 by default. The problem is several plugins depend on ActiveSupport and ActiveSupport doesn't support tzinfo v2. To resolve this problem, there are 2 approaches.
 
@@ -60,7 +60,7 @@ Fluentd supports tzinfo v1.1 or later and recent td-agent / fluent-package / off
 
   so using ActiveSupport for several convenient methods is overengineering.
 
-Former is easier approach.
+The former is the easier approach.
 
 ### I got `no patterns matched` in the log, why?
 

--- a/quickstart/fluent-package-v5-vs-td-agent.md
+++ b/quickstart/fluent-package-v5-vs-td-agent.md
@@ -91,5 +91,5 @@ How to upgrade to `fluent-package`:
 
 * [Upgrade to fluent-package v5](https://www.fluentd.org/blog/upgrade-td-agent-v4-to-v5).
 
-If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under under [the Apache License 2.0.](https://www.apache.org/licenses/LICENSE-2.0)
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under [the Apache License 2.0.](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/quickstart/life-of-a-fluentd-event.md
+++ b/quickstart/life-of-a-fluentd-event.md
@@ -4,7 +4,7 @@ The following article gives a general overview of how events are processed by [F
 
 ## Basic Setup
 
-The configuration file is the fundamental piece to connect all things together, as it allows to define which **Inputs** or listeners [Fluentd](http://fluentd.org) will have and set up common matching rules to route the **Event** data to a specific **Output**.
+The configuration file is the fundamental piece to connect all things together, as it allows you to define which **Inputs** or listeners [Fluentd](http://fluentd.org) will have and set up common matching rules to route the **Event** data to a specific **Output**.
 
 We will use the [`in_http`](../input/http.md) and the [`out_stdout`](../output/stdout.md) plugins as examples to describe the events cycle. The following is a basic definition on the configuration file to specify an `http` input, for short: we will be listening for **HTTP Requests**:
 
@@ -26,7 +26,7 @@ Now, let's define a **Matching** rule to print the incoming requests to the stan
 </match>
 ```
 
-The **Match** sets a rule where each **Incoming** event that arrives with a **Tag** equals to `test.cycle`, will match and use the **Output** plugin type called `stdout`. At this point we have an **Input** type, a _Match_ and an **Output**.
+The **Match** sets a rule where each **Incoming** event that arrives with a **Tag** equal to `test.cycle`, will match and use the **Output** plugin type called `stdout`. At this point we have an **Input** type, a _Match_ and an **Output**.
 
 Let's test this setup using `curl`:
 
@@ -120,7 +120,7 @@ A **Filter** behaves like a rule to pass or reject an event. The following confi
 
 ![Visualization](../.gitbook/assets/screen-shot-2021-03-16-at-12.50.12-pm.png)
 
-As you can see, the new **Filter** definition will be a mandatory step to pass before the control goes to the **Match** section. The **Filter** basically will accept or reject the **Event** based on its `type` and rule. For our example we want to discard any user **logout** action. We only care about the **logins**. The way to accomplish this, is doing a `grep` inside the **Filter** to exclude any message on which `action` key have the **logout** string.
+As you can see, the new **Filter** definition will be a mandatory step to pass before the control goes to the **Match** section. The **Filter** basically will accept or reject the **Event** based on its `type` and rule. For our example we want to discard any user **logout** action. We only care about the **logins**. The way to accomplish this, is doing a `grep` inside the **Filter** to exclude any message on which the `action` key has the **logout** string.
 
 From a terminal, run the following two `curl` commands containing different `action` values:
 
@@ -171,11 +171,11 @@ $ fluentd -c in_http.conf
 2019-12-16 19:08:06.934660000 +0900 test.cycle: {"action":"login","user":2}
 ```
 
-As you can see, the **Events** follow a _step-by-step cycle_ where they are processed in order, from top-to-bottom. The new engine allows to integrate many **Filters** as required. Also, considering that the configuration file may grow and start getting a bit complex for the readers, a new feature called **Labels** has been introduced to solve this potential problem.
+As you can see, the **Events** follow a _step-by-step cycle_ where they are processed in order, from top-to-bottom. The new engine allows you to integrate many **Filters** as required. Also, considering that the configuration file may grow and start getting a bit complex for the readers, a new feature called **Labels** has been introduced to solve this potential problem.
 
 ### Labels
 
-This new implementation called **Labels**, aims to solve the configuration file complexity and allows to define new **Routing** sections that do not follow the top-to-bottom order, instead they act like linked references. Taking the previous example, we will modify the setup as follows:
+This new implementation called **Labels**, aims to solve the configuration file complexity and allows you to define new **Routing** sections that do not follow the top-to-bottom order, instead they act like linked references. Taking the previous example, we will modify the setup as follows:
 
 ```text
 <source>
@@ -214,13 +214,13 @@ The new configuration contains a `@label` parameter under `source` indicating th
 
 ### Buffers
 
-In this example, we use `stdout`, the non-buffered output. But in production, you use outputs in buffered mode e.g. `forward`, `mongodb`, `s3` and etc. An output plugin using buffered mode first stores the received events into buffers and then writes out buffers to a destination after meeting flush conditions. So, using the buffered output, you do not see the received events immediately unlike `stdout` non-buffered output.
+In this example, we use `stdout`, the non-buffered output. But in production, you use outputs in buffered mode e.g. `forward`, `mongodb`, `s3`, etc. An output plugin using buffered mode first stores the received events into buffers and then writes out buffers to a destination after meeting flush conditions. So, using the buffered output, you do not see the received events immediately unlike `stdout` non-buffered output.
 
 Buffer is important for reliability and throughput. See [Output](../output/) and [Buffer](../buffer/) articles.
 
 ## Conclusion
 
-Once the events are reported by the [Fluentd](http://fluend.org) engine on the **Source**, they are processed step-by-step or inside a referenced **Label**. Any **Event** may be filtered out at any moment. The new **Routing Engine** behavior provides more flexibility and makes easier the processing before reaching the **Output** plugin.
+Once the events are reported by the [Fluentd](http://fluentd.org) engine on the **Source**, they are processed step-by-step or inside a referenced **Label**. Any **Event** may be filtered out at any moment. The new **Routing Engine** behavior provides more flexibility and makes easier the processing before reaching the **Output** plugin.
 
 ## Learn More
 

--- a/quickstart/support.md
+++ b/quickstart/support.md
@@ -35,7 +35,7 @@ If you are interested in what's new in each version, please refer to the followi
 * [td-agent's ChangeLog](https://github.com/fluent/fluent-package-builder/blob/master/CHANGELOG-v4.md) (End of Life in Dec, 2023)
 
 {% hint style='danger' %}
-The series of td-agent had already reached End of Life (EOL). td-agent should not be newly installed because no support, no new release and no security updates anymore.
+The series of td-agent had already reached End of Life (EOL). td-agent should not be newly installed because of no support, no new release and no security updates anymore.
 Use fluent-package instead. See [Upgrade to fluent-package v5](https://www.fluentd.org/blog/upgrade-td-agent-v4-to-v5) for migration.
 {% endhint %}
 

--- a/service_discovery/file.md
+++ b/service_discovery/file.md
@@ -14,7 +14,7 @@ Here is an example with `out_forward` updating targets by sending data:
     @type file
     path "/etc/fluentd/sd.yaml"
   </service_discovery>
-</source>
+</match>
 ```
 
 Here is an example of target list file \(`/etc/fluentd/sd.yaml`\):

--- a/service_discovery/srv.md
+++ b/service_discovery/srv.md
@@ -16,7 +16,7 @@ Here is an example of `out_forward` updating the targets to get the SRV record f
     proto tcp
     hostname example.com
   </service_discovery>
-</source>
+</match>
 ```
 
 ## Parameters

--- a/storage/README.md
+++ b/storage/README.md
@@ -44,7 +44,7 @@ Here is an example with `in_sample`:
 
 ## List of 3rd party storage plugins
 
-NOTE: This 3rd party storage plugin list does not fully covers all of them.
+NOTE: This 3rd party storage plugin list does not fully cover all of them.
 
 * [fluent-plugin-storage-leveldb](https://github.com/cosmo0920/fluent-plugin-storage-leveldb)
 * [fluent-plugin-storage-memcached](https://github.com/cosmo0920/fluent-plugin-storage-memcached)
@@ -53,7 +53,7 @@ NOTE: This 3rd party storage plugin list does not fully covers all of them.
 
 ## List of 3rd party Plugins with Storage support
 
-NOTE: This 3rd party plugin list does not fully covers all of them.
+NOTE: This 3rd party plugin list does not fully cover all of them.
 
 * [fluent-plugin-systemd](https://github.com/fluent-plugin-systemd/fluent-plugin-systemd)
 * [fluent-plugin-windows-eventlog](https://github.com/fluent/fluent-plugin-windows-eventlog)

--- a/storage/local.md
+++ b/storage/local.md
@@ -1,6 +1,6 @@
 # local
 
-The `local` storage plugin stores the key-value pair into JSON file on local storage.
+The `local` storage plugin stores the key-value pair into a JSON file on local storage.
 
 ## Parameters
 

--- a/troubleshooting-guide.md
+++ b/troubleshooting-guide.md
@@ -67,7 +67,7 @@ Missing data in your backend destination can also be a wildcard error that needs
 
 ## My logs are being parsed incorrectly
 
-One of Fluentd's big strengths is it's ability to parse logs into a standardized format based on custom formats or well-known formats. However writing regular expressions can be hard to validate and ensure that the proper fields are working. Here are a few tips I recommend
+One of Fluentd's big strengths is its ability to parse logs into a standardized format based on custom formats or well-known formats. However writing regular expressions can be hard to validate and ensure that the proper fields are working. Here are a few tips I recommend
 
 **Suggestions:**
 


### PR DESCRIPTION
Proofread the whole documentation set and fixed genuine English errors only (no stylistic rewording): subject-verb agreement, verb forms, missing/wrong articles and prepositions, singular/plural mismatches, doubled words, and misspellings.

Notable content fixes:
- formatter/tsv.md: the CRLF example was labeled "In non-Windows:"
- service_discovery/{file,srv}.md: `<match>` blocks were closed with `</source>`
- quickstart/life-of-a-fluentd-event.md: broken link `fluend.org` -> `fluentd.org`
- output/webhdfs.md: value must be `webhdfs` (was `webhfds`)
- installation calyptia MSI: `net.ext` -> `net.exe`, `calyptia-fleuntd.log` -> `calyptia-fluentd.log`