### PR TITLE
Add common parameters of <storage> section

### DIFF
--- a/configuration/storage-section.md
+++ b/configuration/storage-section.md
@@ -38,5 +38,23 @@ Third-party plugins may also be installed and configured.
 
 For more details, see plugins documentation.
 
+## Parameters
+
+{% hint style='info' %}
+NOTE: It depends on a plugin's capabilities whether can handle a `<storage>` section or not. See each plugin's documentation in detail.
+{% endhint %}
+
+The following parameters are common to all storage plugins. Individual storage plugins may add their own parameters. See each plugin's documentation in detail.
+
+* **`persistent`** \(bool\) \(optional\): If `true`, the storage reloads its data from the data source before every read/write operation and saves it back after every write operation. This keeps the data source always up-to-date at the cost of an I/O per operation. If `false`, the operations are performed against the in-memory copy only, and saving is left to `autosave` and `save_at_shutdown`.
+  * Default: `false`
+  * Note that some plugins require additional configuration to be persistent. For example, [`local`](../storage/local.md) raises a configuration error unless the plugin `@id` or the `path` parameter is given.
+* **`autosave`** \(bool\) \(optional\): If `true`, the storage periodically saves its data in the background at the `autosave_interval` interval. This is ignored when `persistent` is `true`, because every operation already saves the data.
+  * Default: `true`
+* **`autosave_interval`** \(time\) \(optional\): The interval of the periodic save enabled by `autosave`.
+  * Default: `10`
+* **`save_at_shutdown`** \(bool\) \(optional\): If `true`, the storage saves its data when the plugin shuts down. This takes effect regardless of `persistent` and `autosave`.
+  * Default: `true`
+
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
 


### PR DESCRIPTION
Fluent::Plugin::Storage defines four parameters common to every storage plugin, but they were not documented anywhere.

    lib/fluent/plugin/storage.rb:29-32

      config_param :persistent,        :bool, default: false # load/save with all operations
      config_param :autosave,          :bool, default: true
      config_param :autosave_interval, :time, default: 10
      config_param :save_at_shutdown,  :bool, default: true

The described behaviour follows lib/fluent/plugin_helper/storage.rb:

  * #wrap_instance (l.182-192) wraps the storage in PersistentWrapper when `persistent` is true, which loads before and saves after each operation.
  * #start (l.124-132) registers the autosave timer only when `autosave && !persistent`.
  * #shutdown (l.159-164) saves when `save_at_shutdown` is true, regardless of the other three.