### PR TITLE
Add delimiter parameter of in_tcp

### DIFF
--- a/input/tcp.md
+++ b/input/tcp.md
@@ -141,6 +141,29 @@ You will get something like below:
 
 The maximum number of bytes for the message.
 
+### `delimiter`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | `"\n"` \(newline\) | 0.10.51 |
+
+The payload is read up to this character. Since a TCP stream has no message boundary, `in_tcp` splits the received bytes at every occurrence of this string and passes each part to the `<parse>` section. The delimiter itself is not included in the parsed message.
+
+This is not a pattern but a plain string, so a delimiter of two or more characters can also be specified:
+
+```text
+<source>
+  @type tcp
+  tag tcp.events
+  delimiter "||"
+  <parse>
+    @type json
+  </parse>
+</source>
+```
+
+When `message_length_limit` is set and the data received before the next delimiter exceeds that limit, the buffer is cleared and the remaining bytes are discarded until the next delimiter arrives. The subsequent messages are processed as usual.
+
 ### `<transport>` Section
 
 | type | default | available values | version |
@@ -313,4 +336,3 @@ $ openssl s_client -connect localhost:20001 \
 If the connection gets established successfully, your setup is working fine.
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
-

--- a/input/tcp.md
+++ b/input/tcp.md
@@ -155,7 +155,7 @@ This is not a pattern but a plain string, so a delimiter of two or more characte
 <source>
   @type tcp
   tag tcp.events
-  delimiter "||"
+  delimiter "||"  # It will work expectedly if it splits with '||' against incoming "foo||bar", not work for 'foo|bar'.
   <parse>
     @type json
   </parse>


### PR DESCRIPTION
The parameter is defined at lib/fluent/plugin/in_tcp.rb:45-46

    desc 'The payload is read up to this character.'
    config_param :delimiter, :string, default: "\n"

but input/tcp.md only mentioned it in a comment of the example configuration, with no section under "Parameters".

It is matched with String#index (in_tcp.rb:127), not as a pattern, so a multi-character delimiter works; this was verified by sending '{"k":"a"}||{"k":"b"}||' with `delimiter "||"`.

The interaction with message_length_limit follows in_tcp.rb:153-162, where the buffer is cleared and `discard_till_next_delimiter` is set.

The parameter was introduced at https://github.com/fluent/fluentd/pull/368