### PR TITLE
Add delimiter parameter of in_syslog

### DIFF
--- a/input/syslog.md
+++ b/input/syslog.md
@@ -140,6 +140,20 @@ Message has the message size prefix to delimit:
 
 See also [RFC 6587](https://tools.ietf.org/html/rfc6587#section-3.4).
 
+### `delimiter`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | `"\n"` \(newline\) | 1.5.0 |
+
+The delimiter between syslog messages in one TCP connection. Since a TCP stream has no message boundary, `in_syslog` splits the received bytes at every occurrence of this string and handles each part as one syslog message. The delimiter itself is not included in the message.
+
+This is not a pattern but a plain string, so a delimiter of two or more characters can also be specified.
+
+This parameter is used only when the transport protocol is `tcp` or `tls`. With `udp`, one datagram is always handled as one message, so this parameter has no effect.
+
+It is also ignored when `frame_type` is `octet_count`, because in that framing the message length prefix determines the message boundary and the prefix is always separated from the message by a single space.
+
 ### `format`
 
 Deprecated parameter. Use `<parse>` instead.
@@ -310,7 +324,7 @@ Please see the [logging article](../deployment/logging.md) for further details.
 
 ## TCP Protocol and Message Delimiter
 
-This plugin assumes `\n` for delimiter character between syslog messages in one TCP connection by default. If you use syslog library in your application with `<transport tcp>`, add `\n` to your syslog message. See also [rfc6587](https://tools.ietf.org/html/rfc6587#section-3.4.2).
+This plugin assumes `\n` for delimiter character between syslog messages in one TCP connection by default. If you use syslog library in your application with `<transport tcp>`, add `\n` to your syslog message. See also [rfc6587](https://tools.ietf.org/html/rfc6587#section-3.4.2). If your application uses another character, set it with the `delimiter` parameter.
 
 If your syslog uses octet counting mode, set `frame_type octet_count` in `in_syslog` configuration. See also `frame_type` parameter.
 


### PR DESCRIPTION
The parameter is defined at lib/fluent/plugin/in_syslog.rb:106-107

    desc 'The delimiter value "\n"'
    config_param :delimiter, :string, default: "\n"

but input/syslog.md had no section for it under "Parameters". The "TCP Protocol and Message Delimiter" section described the concept without mentioning that the character is configurable, so a link to the new section is added there too.

The two limitations described come from the code:

  * #start_tcp_server (l.183) is the only reader, so the parameter has no effect on the udp transport, where #start_udp_server (l.176-180) handles one datagram as one message.
  * l.185 is `delimiter = octet_count_frame ? " " : @delimiter`, so `frame_type octet_count` ignores it.

Verified by sending messages over each transport: `delimiter "||"` splits on "||" with <transport tcp>, and is ignored with `frame_type octet_count` and with udp.

Introduced at https://github.com/fluent/fluentd/pull/2378