### PR TITLE
Fix outdated regexp of apache2 parser

### DIFF
--- a/parser/apache2.md
+++ b/parser/apache2.md
@@ -11,7 +11,7 @@ See [Parse Section Configurations](../configuration/parse-section.md)
 Here is the regexp and time format patterns of this plugin:
 
 ```text
-expression /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>(?:[^\"]|\\.)*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>(?:[^\"]|\\.)*)" "(?<agent>(?:[^\"]|\\.)*)")?$/
+expression /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>(?:[^\"]|\\")*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>(?:[^\"]|\\")*)" "(?<agent>(?:[^\"]|\\")*)")?$/
 time_format %d/%b/%Y:%H:%M:%S %z
 ```
 


### PR DESCRIPTION
The regexp shown in parser/apache2.md was the one used before v1.14.2.

The expression was updated at https://github.com/fluent/fluentd/commit/db93f4b99a971ab3748058267118fd061f84bb80