### PR TITLE
Fix parameter default value and type

### DIFF
--- a/configuration/transport-section.md
+++ b/configuration/transport-section.md
@@ -158,7 +158,7 @@ For `<transport tls>`:
   * Default: Mountain View
 * `generate_cert_common_name`: \[string\]
   * Default: `nil`
-* `generate_cert_expiration`: \[integer\]
+* `generate_cert_expiration`: \[time\]
   * Default: \(60 \* 60 \* 24 = 86400\) \* 365 \* 10 = 10 years
 
 ## Cert Digest Algorithm Parameter

--- a/filter/parser.md
+++ b/filter/parser.md
@@ -195,7 +195,7 @@ If `true`, invalid string is replaced with safe characters and re-parse it.
 
 | type | default | version |
 | :--- | :--- | :--- |
-| string | false | 0.14.9 |
+| string | nil | 0.14.9 |
 
 Stores the parsed values with the specified key name prefix.
 
@@ -222,7 +222,7 @@ With above configuration, here is the result:
 
 | type | default | version |
 | :--- | :--- | :--- |
-| string | false | 0.14.9 |
+| string | nil | 0.14.9 |
 
 Stores the parsed values as a hash value in a field.
 

--- a/input/forward.md
+++ b/input/forward.md
@@ -92,7 +92,7 @@ This parameter is deprecated since v1.14.6. Use `<transport>` directive instead.
 
 | type | default | version |
 | :--- | :--- | :--- |
-| bool | false | 0.14.10 |
+| bool | nil | 0.14.10 |
 
 Tries to resolve hostname from IP addresses or not.
 


### PR DESCRIPTION
Four mismatches found by comparing config_param declarations in fluentd v1.19 (0579b12b) with the documented tables.

* inject_key_prefix, hash_value_field (filter/parser.md)

  Both are declared as :string with default nil, but the tables said "false", which is not a valid value for a string parameter:

      config_param :inject_key_prefix, :string, default: nil
      config_param :hash_value_field, :string, default: nil

* resolve_hostname (input/forward.md)

  Declared as :bool with default nil, not false. The distinction matters here because of in_forward.rb:106-113: when source_hostname_key is set, a nil resolve_hostname is promoted to true, while an explicitly configured false raises "resolve_hostname must be true with source_hostname_key". So "unset" and "false" are not interchangeable. input/syslog.md already documents the same parameter of in_syslog, which shares the declaration, as nil.

* generate_cert_expiration (configuration/transport-section.md)

  Declared as :time, not :integer:

      config_param :generate_cert_expiration, :time, default: 10 * 365 * 86400

  The documented default is already correct, only the type was wrong. [time] is the notation used for time parameters in buffer-section.md.

