### PR TITLE
parser: clarify that multiline parser does not join separate events

### DIFF
--- a/filter/parser.md
+++ b/filter/parser.md
@@ -20,6 +20,10 @@ It is included in the Fluentd's core.
 
 `filter_parser` uses built-in parser plugins and your own customized parser plugin, so you can reuse the predefined formats like `apache2`, `json`, etc. See [Parser Plugin Overview](../parser/) for more details
 
+{% hint style='warning' %}
+`filter_parser` receives events which are already split, so `multiline` cannot join them into one record. See [`multiline`](../parser/multiline.md) for the details.
+{% endhint %}
+
 With this example, if you receive this event:
 
 ```text

--- a/parser/multiline.md
+++ b/parser/multiline.md
@@ -8,7 +8,7 @@ The `multiline` parser parses log with `formatN` and `format_firstline` paramete
 This parser plugin itself does not join multiple lines. The logic to buffer lines and detect the start of each record is implemented in `in_tail`.
 
 * `<parse>` in `in_tail`: works as described in this article.
-* `<filter parser>` and other plugins which receive already-split events: cannot join separate events into one record. It can only parse a value which already contains newline characters.
+* `<parse>` section under `<filter>` \([`filter_parser`](../filter/parser.md)\) and other plugins which receive already-split events: cannot join separate events into one record. It can only parse a value which already contains newline characters.
 
 To concatenate multiple events into one record after the input stage, use [`fluent-plugin-concat`](https://github.com/fluent-plugins-nursery/fluent-plugin-concat).
 {% endhint %}

--- a/parser/multiline.md
+++ b/parser/multiline.md
@@ -4,7 +4,14 @@ The `multiline` parser plugin parses multiline logs. This plugin is the multilin
 
 The `multiline` parser parses log with `formatN` and `format_firstline` parameters. `format_firstline` is for detecting the start line of the multiline log. `formatN`, where N's range is \[1..20\], is the list of Regexp format for multiline log.
 
-Unlike other parser plugins, this plugin needs special code in input plugin e.g. handle `format_firstline`. So, currently, `in_tail` plugin works with `multiline` but other input plugins do not work with it.
+{% hint style='warning' %}
+This parser plugin itself does not join multiple lines. The logic to buffer lines and detect the start of each record is implemented in `in_tail`.
+
+* `<parse>` in `in_tail`: works as described in this article.
+* `<filter parser>` and other plugins which receive already-split events: cannot join separate events into one record. It can only parse a value which already contains newline characters.
+
+To concatenate multiple events into one record after the input stage, use [`fluent-plugin-concat`](https://github.com/fluent-plugins-nursery/fluent-plugin-concat).
+{% endhint %}
 
 ## Parameters
 


### PR DESCRIPTION
Closes: #338

`MultilineParser#parse` in `lib/fluent/plugin/parser_multiline.rb` applies the regexp built from `formatN` (compiled with `Regexp::MULTILINE`) to the text it is given, then loops over `Regexp::MatchData#post_match` and yields once per match. So a single call can emit several records, but every bit of state is local to that call: the plugin keeps no buffer across calls, and therefore cannot combine lines which arrive as separate events. It only exposes `has_firstline?` / `firstline?` as helpers for the caller.

The actual line buffering is in `lib/fluent/plugin/in_tail.rb`: it detects the multiline mode with `@multiline_mode = parser_config["@type"].include?("multiline")`, and `parse_multilines` appends lines to a buffer until `@parser.firstline?(line)` matches the next first line.

`lib/fluent/plugin/filter_parser.rb` has no guard against `multiline`: no `ConfigError`, no warning. So a `<filter>` with `@type parser` and `@type multiline` in its `<parse>` section silently parses a single field of an already-split event, which is not what users expect. That is the confusion reported in #338. On top of that, `filter_one_record` adds a new event per `yield`, so one input event can even be expanded into several events.

The existing sentence only talked about input plugins, so it did not cover the `<filter>` case at all.

Note that the wording deliberately avoids saying "multiline does not work in filter". The regexp is compiled in multiline mode, so it can still match if the target field value already contains newline characters. What is impossible is joining *separate events* into one record — hence the pointer to `fluent-plugin-concat`.