### PR TITLE
Fix broken internal links

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -103,7 +103,7 @@ redirects:
   v1.0/articles/out_exec: plugins/output/exec.md
   v1.0/articles/out_mongo_replset: plugins/output/mongo_replset.md
   v1.0/articles/out_relabel: plugins/output/relabel.md
-  v1.0/articles/out_opensearch: plugins/output/opensearch.md
+  v1.0/articles/out_opensearch: output/opensearch.md
 
   # Plugin/Filter
   v1.0/articles/filter_geoip: plugins/filter/geoip.md
@@ -136,7 +136,7 @@ redirects:
   v1.0/articles/formatter_single_value: plugins/formatter/single_value.md
   v1.0/articles/formatter_json: plugins/formatter/json.md
   v1.0/articles/formatter_stdout: plugins/formatter/stdout.md
-  v1.0/articles/formatter_tsv: plugins/formatter/tsv.md
+  v1.0/articles/formatter_tsv: formatter/tsv.md
 
   # Plugin/Buffer
   v1.0/articles/buffer-plugin-overview: plugins/buffer/README.md
@@ -204,7 +204,7 @@ redirects:
   v1.0/articles/api-plugin-helper-storage: developer/api-plugin-helper-storage.md
   v1.0/articles/api-plugin-helper-socket: developer/api-plugin-helper-socket.md
   v1.0/articles/api-plugin-helper-http_server: developer/api-plugin-helper-http_server.md
-  v1.0/articles/api-plugin-helper-metrics: developer/api-plugin-helper-metrics.md
+  v1.0/articles/api-plugin-helper-metrics: plugin-helper-overview/api-plugin-helper-metrics.md
 
   # Obsolete Pages
   v1.0/categories/data-analytics: README.md

--- a/appendix/README.md
+++ b/appendix/README.md
@@ -1,0 +1,10 @@
+# Appendix
+
+This section collects supplementary articles that do not fit into the other sections, such as migration guides and comparisons between the discontinued `td-agent` versions.
+
+## Articles
+
+* [Update from v0.12 to v1](update-from-v0.12.md): how to update Fluentd to v1.0 from v0.12 or earlier.
+* [td-agent v2 vs v3 vs v4](td-agent-v2-vs-v3-vs-v4.md): differences between the `td-agent` series, kept for reference. Note that `td-agent` has already reached End of Life \(EOL\); use [`fluent-package`](../installation/install-fluent-package/) instead.
+
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.

--- a/configuration/config-file.md
+++ b/configuration/config-file.md
@@ -581,7 +581,7 @@ These parameters are reserved and are prefixed with an `@` symbol:
 
 * `@label`: specifies the label symbol. See
 
-  [label](config-file.md#5.-group-filter-and-output-the-label-directive)
+  [label](config-file.md#id-5.-group-filter-and-output-the-label-directive)
 
   section.
 

--- a/deployment/system-config.md
+++ b/deployment/system-config.md
@@ -328,7 +328,7 @@ See [Output Plugins - overflow_action](../output#overflow_action) for details.
 | :---   | :---                                   | :---    |
 | string | nil (use unique path for the instance) | 1.18.0  |
 
-Set this option when recovering buffers ([Source Only Mode - Recovery](source-only-mode.md#Recovery)).
+Set this option when recovering buffers ([Source Only Mode - Recovery](source-only-mode.md#recovery)).
 
 See [Buffer Plugins - file - path](../buffer/file.md#path) for details.
 

--- a/filter/README.md
+++ b/filter/README.md
@@ -53,7 +53,7 @@ Like the `<match>` directive for output plugins, `<filter>` matches against a ta
 
 Only the events whose `message` field contains `cool` get the new field `hostname` with the machine's hostname as its value.
 
-Users can create their own custom plugins with a bit of Ruby. See [this section](../plugin-development/#filter-plugins) for more information.
+Users can create their own custom plugins with a bit of Ruby. See [this section](../plugin-development/api-plugin-filter.md) for more information.
 
 ## Filter Chain Optimization
 

--- a/formatter/README.md
+++ b/formatter/README.md
@@ -48,7 +48,7 @@ The output changes to
 
 i.e., each line is a single JSON object without "time" and "tag" fields. If you want to include "time" and "tag", use [Inject section](../configuration/inject-section.md).
 
-See [this section](../plugin-development/#text-formatter-plugins) to learn how to develop a custom formatter.
+See [this section](../plugin-development/api-plugin-formatter.md) to learn how to develop a custom formatter.
 
 ## List of Built-in Formatters
 

--- a/how-to-guides/apache-to-s3.md
+++ b/how-to-guides/apache-to-s3.md
@@ -37,7 +37,7 @@ You can install Fluentd via major packaging systems.
 
 ### Install plugin
 
-If [`out_s3` (fluent-plugin-s3)](../output/s3) is not installed yet, please install it manually.
+If [`out_s3` (fluent-plugin-s3)](../output/s3.md) is not installed yet, please install it manually.
 
 See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-s3 on your environment.
 

--- a/how-to-guides/http-to-td.md
+++ b/how-to-guides/http-to-td.md
@@ -35,7 +35,7 @@ You can install Fluentd via major packaging systems.
 
 If `out_td` (fluent-plugin-td) is not installed yet, please install it manually.
 
-See [Plugin Management](../installation/post-installation-guide#plugin-management) section for how to install fluent-plugin-td on your environment.
+See [Plugin Management](../installation/post-installation-guide.md#plugin-management) section for how to install fluent-plugin-td on your environment.
 
 {% hint style='info' %}
 If you use `fluent-package`, out_td (fluent-plugin-td) is bundled by default.

--- a/installation/install-by-deb-td-agent-v4.md
+++ b/installation/install-by-deb-td-agent-v4.md
@@ -8,7 +8,7 @@ Fluentd is written in Ruby for flexibility, with performance-sensitive parts in 
 
 That is why [Treasure Data, Inc](http://www.treasuredata.com/) provides **the stable distribution of Fluentd**, called `td-agent`. The differences between Fluentd and `td-agent` can be found [here](https://www.fluentd.org/faqs).
 
-This installation guide is for `td-agent` v4. `td-agent` v4 uses fluentd v1 in the core. See [this page](../quickstart/td-agent-v2-vs-v3-vs-v4.md) for the comparison and supported OS.
+This installation guide is for `td-agent` v4. `td-agent` v4 uses fluentd v1 in the core. See [this page](../appendix/td-agent-v2-vs-v3-vs-v4.md) for the comparison and supported OS.
 
 ## Installing `td-agent`
 

--- a/installation/install-by-rpm-td-agent-v4.md
+++ b/installation/install-by-rpm-td-agent-v4.md
@@ -8,7 +8,7 @@ Fluentd is written in Ruby for flexibility, with performance-sensitive parts in 
 
 That is why [Treasure Data, Inc](http://www.treasuredata.com/) provides **the stable distribution of Fluentd**, called `td-agent`. The differences between Fluentd and `td-agent` can be found [here](https://www.fluentd.org/faqs).
 
-This installation guide is for `td-agent` v4. `td-agent` v4 uses fluentd v1 in the core. See [this page](../quickstart/td-agent-v2-vs-v3-vs-v4.md) for the comparison and supported OS.
+This installation guide is for `td-agent` v4. `td-agent` v4 uses fluentd v1 in the core. See [this page](../appendix/td-agent-v2-vs-v3-vs-v4.md) for the comparison and supported OS.
 
 ## How to install `td-agent`
 

--- a/installation/install-calyptia-fluentd/install-by-deb-calyptia-fluentd.md
+++ b/installation/install-calyptia-fluentd/install-by-deb-calyptia-fluentd.md
@@ -12,11 +12,11 @@ That is why Chronosphere (formerly Calyptia) provides **the alternative stable d
 
 ### Step 0: Before Installation
 
-Please follow the [Pre-installation Guide](before-install.md) to configure your OS properly.
+Please follow the [Pre-installation Guide](../before-install.md) to configure your OS properly.
 
 ### Step 1: Install from Apt Repository
 
-NOTE: If your OS is not supported, consider [gem installation](install-by-gem.md) instead.
+NOTE: If your OS is not supported, consider [gem installation](../install-by-gem.md) instead.
 
 A shell script is provided to automate the installation process for each version. The shell script registers a new apt repository at `/etc/apt/sources.list.d/calyptia-fluentd.sources` and installs the `calyptia-fluentd` deb package.
 
@@ -94,14 +94,14 @@ $ sudo tail -n 1 /var/log/calyptia-fluentd/calyptia-fluentd.log
 You are now ready to collect real logs with Fluentd. Refer to the following tutorials on how to collect data from various sources:
 
 * Basic Configuration
-  * [Config File](../configuration/config-file.md)
+  * [Config File](../../configuration/config-file.md)
 * Application Logs
-  * [Ruby](../language-bindings/ruby.md), [Java](../language-bindings/java.md), [Python](../language-bindings/python.md), [PHP](../language-bindings/php.md),
+  * [Ruby](../../language-bindings/ruby.md), [Java](../../language-bindings/java.md), [Python](../../language-bindings/python.md), [PHP](../../language-bindings/php.md),
 
-    [Perl](../language-bindings/perl.md), [Node.js](../language-bindings/nodejs.md), [Scala](../language-bindings/scala.md)
+    [Perl](../../language-bindings/perl.md), [Node.js](../../language-bindings/nodejs.md), [Scala](../../language-bindings/scala.md)
 * Examples
-  * [Store Apache Log into Amazon S3](../how-to-guides/apache-to-s3.md)
-  * [Store Apache Log into MongoDB](../how-to-guides/apache-to-mongodb.md)
-  * [Data Collection into HDFS](../how-to-guides/http-to-hdfs.md)
+  * [Store Apache Log into Amazon S3](../../how-to-guides/apache-to-s3.md)
+  * [Store Apache Log into MongoDB](../../how-to-guides/apache-to-mongodb.md)
+  * [Data Collection into HDFS](../../how-to-guides/http-to-hdfs.md)
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.

--- a/installation/install-calyptia-fluentd/install-by-dmg-calyptia-fluentd.md
+++ b/installation/install-calyptia-fluentd/install-by-dmg-calyptia-fluentd.md
@@ -22,7 +22,7 @@ Download and install the `.dmg` package:
 
 * [calyptia-fluentd v1](https://calyptia-fluentd.s3.us-east-2.amazonaws.com/index.html?prefix=1/macos/)
 
-NOTE: If your OS is not supported, consider [gem installation](install-by-gem.md) instead.
+NOTE: If your OS is not supported, consider [gem installation](../install-by-gem.md) instead.
 NOTE: Since calyptia-fluentd v1.3.1, intel version and apple silicon version of packages are provided.
 `-intel` suffix is for Intel version and `-apple` suffix is for Apple Silicon.
 
@@ -73,14 +73,14 @@ To uninstall `calyptia-fluentd` from macOS, remove these files / directories:
 You are now ready to collect real logs with Fluentd. Refer to the following tutorials on how to collect data from various sources:
 
 * Basic Configuration
-  * [Config File](../configuration/config-file.md)
+  * [Config File](../../configuration/config-file.md)
 * Application Logs
-  * [Ruby](../language-bindings/ruby.md), [Java](../language-bindings/java.md), [Python](../language-bindings/python.md), [PHP](../language-bindings/php.md),
+  * [Ruby](../../language-bindings/ruby.md), [Java](../../language-bindings/java.md), [Python](../../language-bindings/python.md), [PHP](../../language-bindings/php.md),
 
-    [Perl](../language-bindings/perl.md), [Node.js](../language-bindings/nodejs.md), [Scala](../language-bindings/scala.md)
+    [Perl](../../language-bindings/perl.md), [Node.js](../../language-bindings/nodejs.md), [Scala](../../language-bindings/scala.md)
 * Examples
-  * [Store Apache Log into Amazon S3](../how-to-guides/apache-to-s3.md)
-  * [Store Apache Log into MongoDB](../how-to-guides/apache-to-mongodb.md)
-  * [Data Collection into HDFS](../how-to-guides/http-to-hdfs.md)
+  * [Store Apache Log into Amazon S3](../../how-to-guides/apache-to-s3.md)
+  * [Store Apache Log into MongoDB](../../how-to-guides/apache-to-mongodb.md)
+  * [Data Collection into HDFS](../../how-to-guides/http-to-hdfs.md)
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.

--- a/installation/install-calyptia-fluentd/install-by-msi-calyptia-fluentd.md
+++ b/installation/install-calyptia-fluentd/install-by-msi-calyptia-fluentd.md
@@ -18,7 +18,7 @@ Currently, calyptia-fluentd is on v1 only.
 
 Download the latest MSI installer from [the download page](https://calyptia-fluentd.s3.us-east-2.amazonaws.com/index.html?prefix=1/windows/). Run the installer and follow the wizard.
 
-![calyptia-fluentd installation wizard](../.gitbook/assets/calyptia-fluentd1-wizard.png)
+![calyptia-fluentd installation wizard](../../.gitbook/assets/calyptia-fluentd1-wizard.png)
 
 **Note:** Calyptia-Fluentd is a drop-in-replacement agent of other Fluentd stable distribution. Currently, we use the same Windows Service name which is `fluentdwinsvc`. This is because when you already installed other agent which registers Windows Service as `fluentdwinsvc`, you must uninstall already installed Windows Service which uses `fluentdwinsvc` as service name.
 
@@ -103,18 +103,18 @@ C:\opt\calyptia-fluentd> calyptia-fluentd-gem install fluent-plugin-xyz --versio
 You are now ready to collect real logs with Fluentd. Refer to the following tutorials on how to collect data from various sources:
 
 * Basic Configuration
-  * [Config File](../configuration/config-file.md)
+  * [Config File](../../configuration/config-file.md)
 * Application Logs
-  * [Ruby](../language-bindings/ruby.md)
-  * [Java](../language-bindings/java.md)
-  * [Python](../language-bindings/python.md)
-  * [PHP](../language-bindings/php.md)
-  * [Perl](../language-bindings/perl.md)
-  * [Node.js](../language-bindings/nodejs.md)
-  * [Scala](../language-bindings/scala.md)
+  * [Ruby](../../language-bindings/ruby.md)
+  * [Java](../../language-bindings/java.md)
+  * [Python](../../language-bindings/python.md)
+  * [PHP](../../language-bindings/php.md)
+  * [Perl](../../language-bindings/perl.md)
+  * [Node.js](../../language-bindings/nodejs.md)
+  * [Scala](../../language-bindings/scala.md)
 * Examples
-  * [Store Apache Log into Amazon S3](../how-to-guides/apache-to-s3.md)
-  * [Store Apache Log into MongoDB](../how-to-guides/apache-to-mongodb.md)
-  * [Data Collection into HDFS](../how-to-guides/http-to-hdfs.md)
+  * [Store Apache Log into Amazon S3](../../how-to-guides/apache-to-s3.md)
+  * [Store Apache Log into MongoDB](../../how-to-guides/apache-to-mongodb.md)
+  * [Data Collection into HDFS](../../how-to-guides/http-to-hdfs.md)
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.

--- a/installation/install-calyptia-fluentd/install-by-rpm-calyptia-fluentd.md
+++ b/installation/install-calyptia-fluentd/install-by-rpm-calyptia-fluentd.md
@@ -12,13 +12,13 @@ That is why Chronosphere (formerly Calyptia) provides **the alternative stable d
 
 ### Step 0: Before Installation
 
-Please follow the [Pre-installation Guide](before-install.md) to configure your OS properly.
+Please follow the [Pre-installation Guide](../before-install.md) to configure your OS properly.
 
 ### Step 1: Install from `rpm` Repository
 
-It is highly recommended to set up `ntpd` on the node to prevent invalid timestamps in the logs. See [Pre-installation Guide](before-install.md).
+It is highly recommended to set up `ntpd` on the node to prevent invalid timestamps in the logs. See [Pre-installation Guide](../before-install.md).
 
-NOTE: If your OS is not supported, consider [gem installation](install-by-gem.md) instead.
+NOTE: If your OS is not supported, consider [gem installation](../install-by-gem.md) instead.
 
 #### Red Hat / CentOS
 
@@ -98,14 +98,14 @@ $ sudo tail -n 1 /var/log/calyptia-fluentd/calyptia-fluentd.log
 You are now ready to collect real logs with Fluentd. Refer to the following tutorials on how to collect data from various sources:
 
 * Basic Configuration
-  * [Config File](../configuration/config-file.md)
+  * [Config File](../../configuration/config-file.md)
 * Application Logs
-  * [Ruby](../language-bindings/ruby.md), [Java](../language-bindings/java.md), [Python](../language-bindings/python.md), [PHP](../language-bindings/php.md),
+  * [Ruby](../../language-bindings/ruby.md), [Java](../../language-bindings/java.md), [Python](../../language-bindings/python.md), [PHP](../../language-bindings/php.md),
 
-    [Perl](../language-bindings/perl.md), [Node.js](../language-bindings/nodejs.md), [Scala](../language-bindings/scala.md)
+    [Perl](../../language-bindings/perl.md), [Node.js](../../language-bindings/nodejs.md), [Scala](../../language-bindings/scala.md)
 * Examples
-  * [Store Apache Log into Amazon S3](../how-to-guides/apache-to-s3.md)
-  * [Store Apache Log into MongoDB](../how-to-guides/apache-to-mongodb.md)
-  * [Data Collection into HDFS](../how-to-guides/http-to-hdfs.md)
+  * [Store Apache Log into Amazon S3](../../how-to-guides/apache-to-s3.md)
+  * [Store Apache Log into MongoDB](../../how-to-guides/apache-to-mongodb.md)
+  * [Data Collection into HDFS](../../how-to-guides/http-to-hdfs.md)
 
 If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.

--- a/installation/install-fluent-package/install-by-dmg-fluent-package.md
+++ b/installation/install-fluent-package/install-by-dmg-fluent-package.md
@@ -29,7 +29,7 @@ Download and install the `.dmg` package:
 
 * [fluent-package v5](https://td-agent-package-browser.herokuapp.com/5/macosx)
 
-NOTE: If your OS is not supported, consider [gem installation](install-by-gem.md) instead.
+NOTE: If your OS is not supported, consider [gem installation](../install-by-gem.md) instead.
 
 ### Step 2: Launch `fluentd`
 

--- a/output/forward.md
+++ b/output/forward.md
@@ -509,7 +509,7 @@ Overwrites the default value in this plugin.
 
 ### How to connect to a TLS/SSL enabled server?
 
-If you have set up [TLS/SSL encryption](../input/forward.md#how-to-enable-tls/ssl-encryption) for the receiving server, you need to tell the output forwarder to use encryption by setting the `transport` parameter:
+If you have set up [TLS/SSL encryption](../input/forward.md#how-to-enable-tls-encryption) for the receiving server, you need to tell the output forwarder to use encryption by setting the `transport` parameter:
 
 ```text
 <match debug.**>
@@ -542,7 +542,7 @@ After updating the settings, please confirm that the forwarded data is being rec
 
 ### How to connect to a TLS/SSL enabled server with Windows Certstore Certificate?
 
-If you have set up [TLS/SSL encryption](../input/forward.md#how-to-enable-tls/ssl-encryption) in the receiving server, you need to tell the output forwarder to use encryption by setting the `transport` parameter.
+If you have set up [TLS/SSL encryption](../input/forward.md#how-to-enable-tls-encryption) in the receiving server, you need to tell the output forwarder to use encryption by setting the `transport` parameter.
 
 Valid logical store names are:
 


### PR DESCRIPTION
## Summary

Audited all 206 markdown files (2,774 links) plus the 177 redirects in `.gitbook.yaml`, and fixed every internal link that does not resolve — 63 links across 14 files, 3 redirects, and one new file.

External URLs are deliberately out of scope here; they need per-URL investigation for replacements and will be sent as a separate PR.

## Path fixes (56)

| Where | Problem | Fix |
| :--- | :--- | :--- |
| `installation/install-calyptia-fluentd/*.md` (51 links) | These four install guides live one directory deeper than the links assume, so every relative link is short by one level. | Add one `../`. This matches the sibling `install-fluent-package/` guides, which already use `../../configuration/config-file.md` and `../before-install.md`. |
| `installation/install-fluent-package/install-by-dmg-fluent-package.md` (1) | Same problem on the link to `install-by-gem.md`; the other guides in that directory already use `../install-by-gem.md`. | `../install-by-gem.md` |
| `installation/install-by-{deb,rpm}-td-agent-v4.md` (2) | Points at `../quickstart/td-agent-v2-vs-v3-vs-v4.md`, but that page is in `appendix/`. | `../appendix/td-agent-v2-vs-v3-vs-v4.md` |
| `how-to-guides/apache-to-s3.md` (1) | `../output/s3` is missing the `.md` extension. | `../output/s3.md` |
| `how-to-guides/http-to-td.md` (1) | `../installation/post-installation-guide#plugin-management` is missing the `.md` extension. | `../installation/post-installation-guide.md#plugin-management` |

## New file (1)

`SUMMARY.md` lists `* [Appendix](appendix/README.md)`, but that file does not exist, so the Appendix section has no landing page. Added `appendix/README.md` with a short introduction and links to the two articles it contains.

## Anchor fixes (7)

These were verified against the `id` attributes actually rendered on docs.fluentd.org, not against a local build — honkit generates heading anchors by different rules than GitBook does, so a local build cannot be used to check them.

| Where | Old | New |
| :--- | :--- | :--- |
| `deployment/system-config.md` | `source-only-mode.md#Recovery` | `source-only-mode.md#recovery` |
| `output/forward.md` (2 links) | `../input/forward.md#how-to-enable-tls/ssl-encryption` | `../input/forward.md#how-to-enable-tls-encryption` |
| `configuration/config-file.md` | `config-file.md#5.-group-filter-and-output-the-label-directive` | `config-file.md#id-5.-group-filter-and-output-the-label-directive` |
| `filter/README.md` | `../plugin-development/#filter-plugins` | `../plugin-development/api-plugin-filter.md` |
| `formatter/README.md` | `../plugin-development/#text-formatter-plugins` | `../plugin-development/api-plugin-formatter.md` |

The heading in `input/forward.md` is now "How to Enable TLS Encryption", so the old `tls/ssl` anchor no longer exists. The "Filter Plugins" and "Text Formatter Plugins" sections were removed from `plugin-development/README.md` and are now separate pages, so those two links point at the pages instead of at anchors that no longer exist.

GitBook prefixes `id-` to anchors generated from headings that start with a digit, so the id of "5. Group filter and output: the label directive" is `id-5.-group-filter-and-output-the-label-directive`. GitBook's own on-page table of contents links to it that way, but the markdown link in the body did not. It is the only link in the repository affected.

## Redirect fixes in `.gitbook.yaml` (3)

Most redirect targets name paths that no longer exist in the repository, but GitBook tracks those file moves internally and resolves them anyway — for example `v1.0/articles/in_http` still points at `plugins/input/http.md` and correctly lands on `/input/http`. I checked all 177 against the live site; three of them return 404, because those pages were never at the recorded path for GitBook to track (`plugins/output/opensearch.md` and `developer/api-plugin-helper-metrics.md` have no history at all, and `plugins/formatter/tsv.md` was deleted and re-added, which broke the chain).

| Redirect | Old target | New target |
| :--- | :--- | :--- |
| `v1.0/articles/out_opensearch` | `plugins/output/opensearch.md` | `output/opensearch.md` |
| `v1.0/articles/formatter_tsv` | `plugins/formatter/tsv.md` | `formatter/tsv.md` |
| `v1.0/articles/api-plugin-helper-metrics` | `developer/api-plugin-helper-metrics.md` | `plugin-helper-overview/api-plugin-helper-metrics.md` |

The remaining 174 redirects resolve correctly and are left untouched.

## Verification

Three independent checks:

1. Source analysis — resolve every link target against the working tree (code blocks and inline code spans excluded). 58 unresolved before, 1 after (see below).
2. honkit build crawl — `honkit build` and walk every `href`/`src` in the output. 47,503 relative links, 0 unresolved.
3. Live-site check — fetch each target page from docs.fluentd.org and compare against the real `id` values, and request every redirect source. 110 anchor-bearing links, 7 broken before, 0 after; 177 redirects, 4 broken before, 1 after (see below).

`codespell` passes.

## Deliberately left for a follow-up PR

`plugins/input/dummy.md` is the only file left under `plugins/`. It is not listed in `SUMMARY.md`, so GitBook does not publish it, which is why `v1.0/articles/in_dummy` returns 404 — and its own link to `/input/sample.md` is a root-absolute path that does not resolve. `in_dummy` was renamed `in_sample` in v1.11.12 but [the plugin still ships](https://github.com/fluent/fluentd/blob/master/lib/fluent/plugin/in_dummy.rb), so the page should move to `input/dummy.md` and be added to the TOC rather than be dropped. That is a file move plus a `SUMMARY.md` change, so it is kept out of this PR to avoid conflicts.

## Also out of scope

* 12 external URLs (21 occurrences) are broken or redirected. Separate PR.
* 5 `http://localhost:*` links are operational examples inside walkthroughs, not navigation.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
