### PR TITLE
Add parser/apache.md

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -117,6 +117,7 @@
   * [stdout](filter/stdout.md)
 * [Parser Plugins](parser/README.md)
   * [regexp](parser/regexp.md)
+  * [apache](parser/apache.md)
   * [apache2](parser/apache2.md)
   * [apache\_error](parser/apache_error.md)
   * [nginx](parser/nginx.md)

--- a/configuration/parse-section.md
+++ b/configuration/parse-section.md
@@ -46,6 +46,7 @@ The `@type` parameter specifies the type of the parser plugin.
 Here's the list of built-in parser plugins:
 
 * [`regexp`](../parser/regexp.md)
+* [`apache`](../parser/apache.md)
 * [`apache2`](../parser/apache2.md)
 * [`apache_error`](../parser/apache_error.md)
 * [`nginx`](../parser/nginx.md)

--- a/parser/README.md
+++ b/parser/README.md
@@ -53,6 +53,7 @@ this case, several options are available to allow read access:
 ## List of Built-in Parsers
 
 * [`regexp`](regexp.md)
+* [`apache`](apache.md)
 * [`apache2`](apache2.md)
 * [`apache_error`](apache_error.md)
 * [`nginx`](nginx.md)

--- a/parser/apache.md
+++ b/parser/apache.md
@@ -1,0 +1,54 @@
+# apache
+
+The `apache` parser plugin parses the default Apache logs \(Common Log Format with the optional referer and user-agent fields\).
+
+## Parameters
+
+See [Parse Section Configurations](../configuration/parse-section.md).
+
+## Regexp Patterns
+
+Here is the regexp and time format patterns of this plugin:
+
+```text
+expression /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/
+time_format %d/%b/%Y:%H:%M:%S %z
+```
+
+`host`, `user`, `method`, `path`, `code`, `size`, `referer` and `agent` are included in the event record. `time` is used for the event time.
+
+This plugin is a [`regexp`](regexp.md) parser with the above defaults, so every field is kept as a string and a `-` value is kept as it is.
+
+## Difference from `apache2`
+
+The [`apache2`](apache2.md) parser accepts a wider range of lines: its `path` may contain spaces, the protocol token after the path is optional, and `path`, `referer` and `agent` may contain escaped double quotes. It also converts `code` and `size` into the integer type and interprets the `-` value as `nil`. The `apache` parser does none of these: it requires the protocol token, does not allow a space in `path`, and returns all the fields as a string.
+
+## Example
+
+This incoming event:
+
+```text
+192.168.0.1 - - [28/Feb/2013:12:00:00 +0900] "GET / HTTP/1.1" 200 777 "-" "Opera/12.0"
+```
+
+is parsed as:
+
+```text
+time:
+1362020400 (28/Feb/2013:12:00:00 +0900)
+
+record:
+{
+  "host"   : "192.168.0.1",
+  "user"   : "-",
+  "method" : "GET",
+  "path"   : "/",
+  "code"   : "200",
+  "size"   : "777",
+  "referer": "-",
+  "agent"  : "Opera/12.0"
+}
+```
+
+If this article is incorrect or outdated, or omits critical information, please [let us know](https://github.com/fluent/fluentd-docs-gitbook/issues?state=open). [Fluentd](http://www.fluentd.org/) is an open-source project under [Cloud Native Computing Foundation \(CNCF\)](https://cncf.io/). All components are available under the Apache 2 License.
+


### PR DESCRIPTION
lib/fluent/plugin/parser_apache.rb registers the "apache" parser via `Plugin.register_parser("apache", self)`, but it had no documentation page while apache2 and apache_error do.

The plugin is a RegexpParser subclass with only two defaults:

    config_set_default :expression, /^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$/
    config_set_default :time_format, "%d/%b/%Y:%H:%M:%S %z"

The page follows parser/nginx.md, which documents the other RegexpParser subclass. The Example output was verified by running the parser against the sample line: all fields are returned as String and "-" is kept verbatim, unlike apache2 which casts code/size to Integer and maps "-" to nil.
