### PR TITLE
Fix dead external links

### DIFF
--- a/installation/install-by-gem.md
+++ b/installation/install-by-gem.md
@@ -38,14 +38,13 @@ The second command starts Fluentd as a daemon. If you want to stop its daemon, y
 
 It is highly recommended to set up `ntpd` on the node to prevent invalid timestamps in your logs.
 
-For large deployments, you must use [`jemalloc`](http://www.canonware.com/jemalloc/) to avoid memory fragmentation. This is already included in the [`rpm`](install-fluent-package/install-by-rpm-fluent-package.md) and [`deb`](install-fluent-package/install-by-deb-fluent-package.md) packages.
+For large deployments, you must use [`jemalloc`](https://jemalloc.net/) to avoid memory fragmentation. This is already included in the [`rpm`](install-fluent-package/install-by-rpm-fluent-package.md) and [`deb`](install-fluent-package/install-by-deb-fluent-package.md) packages.
 
 The Fluentd gem does not come with `/etc/init.d/` scripts. You should use Process Management tools such as:
 
 * [`daemontools`](https://cr.yp.to/daemontools.html)
 * [`runit`](https://smarden.org/runit/)
 * [`supervisord`](https://supervisord.org/)
-* [`upstart`](http://upstart.ubuntu.com/)
 * `systemd`
 
 ## Next Steps

--- a/installation/install-from-source.md
+++ b/installation/install-from-source.md
@@ -47,7 +47,7 @@ The second command starts Fluentd as a daemon. If you want to stop its daemon, y
 
 It is highly recommended to set up `ntpd` on the node to prevent invalid timestamps in your logs.
 
-For large deployments, you must use [`jemalloc`](http://www.canonware.com/jemalloc/) to avoid memory fragmentation. This is already included in the [`rpm`](install-fluent-package/install-by-rpm-fluent-package.md) and [`deb`](install-fluent-package/install-by-deb-fluent-package.md) packages.
+For large deployments, you must use [`jemalloc`](https://jemalloc.net/) to avoid memory fragmentation. This is already included in the [`rpm`](install-fluent-package/install-by-rpm-fluent-package.md) and [`deb`](install-fluent-package/install-by-deb-fluent-package.md) packages.
 
 ## Troubleshooting
 

--- a/parser/json.md
+++ b/parser/json.md
@@ -32,7 +32,7 @@ Set the buffer size that Yajl will use when parsing streaming input.
 
 If you specify the smaller buffer size, you could get outcome response instantaneously in exchange for performance penalty.
 
-See also: [Method: Yajl::Parser\#parse](https://www.rubydoc.info/github/brianmario/yajl-ruby/Yajl%2FParser:parse)
+See also: [Method: Yajl::Parser\#parse](https://www.rubydoc.info/gems/yajl-ruby/Yajl%2FParser:parse)
 
 ### `time_type`
 


### PR DESCRIPTION
Three of the external URLs left over from the link audit no longer resolve. The remaining ones need a replacement target to be decided first, so they are not touched here.

* upstart (installation/install-by-gem.md)

  upstart.ubuntu.com no longer resolves. Upstart stopped being developed and Ubuntu moved to systemd in 15.04, so it is dropped from the list rather than repointed: that list tells the reader which process management tools to use, and there is no longer a reason to suggest this one.

* jemalloc (installation/install-by-gem.md, installation/install-from-source.md)

  www.canonware.com times out. The project site is now https://jemalloc.net/.

* yajl-ruby (parser/json.md)

  rubydoc.info returns 404 for the github/brianmario/yajl-ruby tree. The gems/ path serves the same page, and it documents the buffer_size parameter this paragraph is about.