### PR TITLE
parser_multiline: correct the formatN parameter table

### DIFF
--- a/parser/multiline.md
+++ b/parser/multiline.md
@@ -27,7 +27,7 @@ If `format_firstline` is not specified, the input plugin should store the unmatc
 
 | type | default | version |
 | :--- | :--- | :--- |
-| string | `nil` | 0.14.0 |
+| regexp | required parameter | 0.14.0 |
 
 It is a required parameter.
 


### PR DESCRIPTION
## What

Fix the `formatN` parameter table on `parser/multiline.md`:

- `default`: `` `nil` `` → `required parameter`
- `type`: `string` → `regexp`

## Why

The article states "It is a required parameter." right, yet the table listed `nil` as the default. A required parameter cannot have a default value, so the two descriptions contradicted each other.

`formatN` is also not declared as a `config_param`. In `lib/fluent/plugin/parser_multiline.rb`, only `format_firstline` and `unmatched_lines` are declared; `format1` to `format20` are read directly from the config element inside `parse_formats`. So the `string` / `nil` shown in the table had no basis in the config system.

`formatN` is validated as a regular expression by `check_format_regexp`.

```ruby
      def check_format_regexp(format, key)
        if format[0] == '/' && format[-1] == '/'
          begin
            Regexp.new(format[1..-2], Regexp::MULTILINE)
          rescue => e
            raise Fluent::ConfigError, "Invalid regexp in #{key}: #{e}"
          end
        else
          raise Fluent::ConfigError, "format should be Regexp, need //, in #{key}: '#{format}'"
        end
      end
```

https://github.com/fluent/fluentd/blob/469d5c239113f36788046f6222d840aee8615047/lib/fluent/plugin/parser_multiline.rb#L139-L149

## Note

This addresses the remaining point of #466. That issue raised two problems: the undocumented `got incomplete line before first line` warning (handled in #655) and this `formatN` table mismatch. #466 was closed after #655 was merged, so this PR references it for context only.

Refs #466
