### PR TITLE
in_tcp, in_udp, in_syslog: document deprecated parameters

### DIFF
--- a/input/syslog.md
+++ b/input/syslog.md
@@ -286,6 +286,16 @@ The field name of the client's hostname. If set, the client's hostname will be s
 
 The field name of the client's address. If set, the client's address will be set to its key.
 
+### `include_source_host`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| bool | false | 0.10.53 |
+
+This parameter is deprecated. Use `source_hostname_key` or `source_address_key` instead.
+
+If `true`, adds the source host to the event record.
+
 ### `severity_key`
 
 | type | default | version |

--- a/input/tcp.md
+++ b/input/tcp.md
@@ -133,6 +133,16 @@ You will get something like below:
 }
 ```
 
+### `source_host_key`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | nil | 0.10.51 |
+
+This parameter is deprecated. Use `source_hostname_key` instead.
+
+The field name of the client's hostname.
+
 ### `message_length_limit`
 
 | type | default | version |

--- a/input/udp.md
+++ b/input/udp.md
@@ -119,11 +119,31 @@ You will get something like this:
 }
 ```
 
+### `source_host_key`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | nil | 0.10.51 |
+
+This parameter is deprecated. Use `source_hostname_key` instead.
+
+The field name of the client's hostname.
+
 ### `message_length_limit`
 
 | type | default | version |
 | :--- | :--- | :--- |
 | size | 4096 | 0.14.14 |
+
+The maximum number of bytes for the message.
+
+### `body_size_limit`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| size | nil | 0.10.51 |
+
+This parameter is deprecated. Use `message_length_limit` instead.
 
 The maximum number of bytes for the message.
 


### PR DESCRIPTION
Document the deprecated parameters of the socket-based input plugins. Each is still accepted by the plugin, but was missing from the docs.

- in_tcp: `source_host_key` (use `source_hostname_key` instead)
- in_udp: `source_host_key` (use `source_hostname_key` instead)
- in_udp: `body_size_limit` (use `message_length_limit` instead)
- in_syslog: `include_source_host` (use `source_hostname_key` or `source_address_key` instead)