### PR TITLE
Add parameters which were missing from the docs

### DIFF
--- a/formatter/json.md
+++ b/formatter/json.md
@@ -9,6 +9,18 @@ By default, `json` formatter result doesn't contain `tag` and `time` fields.
 * [Common Parameters](../configuration/plugin-common-parameters.md)
 * [Format section configurations](../configuration/format-section.md)
 
+### `json_parser`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | oj | 0.14.0 |
+
+Sets the library used to generate JSON. Despite its name, this parameter is for generating JSON, not for parsing it.
+
+If `oj` is specified, the [`oj`](https://github.com/ohler55/oj) gem is used. The gem must be installed separately because Fluentd does not require it by default. If it is not installed, the `json` standard library is used as a fallback and it is reported in the log at the info level.
+
+Any other value, including `yajl`, selects the `json` standard library. Unlike [`json_parser`](../parser/json.md#json_parser) of the `json` parser plugin, this parameter is not restricted to a fixed list of values.
+
 ### `add_newline`
 
 | type | default | version |

--- a/formatter/json.md
+++ b/formatter/json.md
@@ -13,7 +13,7 @@ By default, `json` formatter result doesn't contain `tag` and `time` fields.
 
 | type | default | version |
 | :--- | :--- | :--- |
-| string | oj | 0.14.0 |
+| string | oj | 0.12.19 |
 
 Sets the library used to generate JSON. Despite its name, this parameter is for generating JSON, not for parsing it.
 

--- a/input/exec.md
+++ b/input/exec.md
@@ -88,6 +88,24 @@ Control target IO:
 
 `read_with_stderr` is mainly for debug.
 
+### `encoding`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | nil | 1.17.1 |
+
+The encoding to receive the result of the command, especially for non-ASCII characters.
+
+By default, the result is read as `ASCII-8BIT`. If this parameter is specified, the result is read with the given encoding and then converted to `UTF-8`.
+
+You can get the list of supported encodings with this command:
+
+```text
+$ ruby -e 'p Encoding.name_list.sort'
+```
+
+An encoding name which Ruby does not know causes a configuration error.
+
 ### `<parse>` section
 
 | required | multi | version |

--- a/input/forward.md
+++ b/input/forward.md
@@ -51,6 +51,16 @@ The port to listen to.
 
 The bind address to listen to.
 
+### `backlog`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| integer | nil | 0.10.36 |
+
+The maximum length of the queue for pending connections.
+
+If not specified, Ruby's default \(`Socket::SOMAXCONN`\) is used.
+
 ### `tag`
 
 | type | default | version |
@@ -94,7 +104,7 @@ This parameter is deprecated since v1.14.6. Use `<transport>` directive instead.
 | :--- | :--- | :--- |
 | bool | nil | 0.14.10 |
 
-Tries to resolve hostname from IP addresses or not.
+Tries to resolve hostname from IP addresses or not. Cannot set `false` when `source_hostname_key` is set.
 
 ### `deny_keepalive`
 

--- a/input/syslog.md
+++ b/input/syslog.md
@@ -304,7 +304,7 @@ If `true`, adds the source address to the event record. The field name is specif
 
 The field name used when `include_source_host` is `true`. This parameter has no effect on its own.
 
-Since `include_source_host` is deprecated, use `source_address_key` instead. Specifying `source_address_key` and `include_source_host` at the same time causes a configuration error.
+Since 0.14.11, `include_source_host` is deprecated, use `source_address_key` instead. Specifying `source_address_key` and `include_source_host` at the same time causes a configuration error.
 
 ### `severity_key`
 

--- a/input/syslog.md
+++ b/input/syslog.md
@@ -294,7 +294,17 @@ The field name of the client's address. If set, the client's address will be set
 
 This parameter is deprecated. Use `source_hostname_key` or `source_address_key` instead.
 
-If `true`, adds the source host to the event record.
+If `true`, adds the source address to the event record. The field name is specified by [`source_host_key`](#source_host_key).
+
+### `source_host_key`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | `source_host` | 0.10.53 |
+
+The field name used when `include_source_host` is `true`. This parameter has no effect on its own.
+
+Since `include_source_host` is deprecated, use `source_address_key` instead. Specifying `source_address_key` and `include_source_host` at the same time causes a configuration error.
 
 ### `severity_key`
 

--- a/input/tail.md
+++ b/input/tail.md
@@ -121,6 +121,27 @@ path_timezone "+00"
 
 For timezone format, see [Timezone Section](../configuration/format-section.md#time-parameters).
 
+### `path_delimiter`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | `,` | 1.9.1 |
+
+The delimiter used to split the `path` parameter into multiple paths.
+
+Specify another character if your paths contain `,`:
+
+```text
+path /path/to/2014,04,01.log|/path/to/b.log
+path_delimiter |
+```
+
+`/`, `*` and `%` cannot be used because they are reserved for path patterns.
+
+This parameter does not apply to `exclude_path`, which is always separated by `,`.
+
+To use `glob_policy always`, this parameter must be changed from its default. See the `glob_policy` section.
+
 ### `glob_policy`
 
 | type | default | available values | version |

--- a/parser/multiline.md
+++ b/parser/multiline.md
@@ -33,6 +33,16 @@ It is a required parameter.
 
 Specifies the regexp patterns. For readability, you can separate the regexp patterns into multiple `formatN` parameters. See the Rails Log's example below. These patterns are joined and then construct a regexp pattern with multiline mode.
 
+### `unmatched_lines`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | nil | 1.9.3 |
+
+If set, the lines which do not match the patterns are emitted as a record with the `unmatched_line` field instead of being discarded.
+
+With `in_tail`, this parameter is overwritten by the value of [`emit_unmatched_lines`](../input/tail.md#emit_unmatched_lines). Set `emit_unmatched_lines` on `in_tail` instead of setting this parameter in the `<parse>` section.
+
 ## Example
 
 ### Rails Log


### PR DESCRIPTION
Six parameters are accepted by the plugins but were not described anywhere in the documentation. Users could only find them by reading the plugin source.

* formatter/json.md   json_parser      (0.14.0)
* input/exec.md       encoding         (1.17.1)
* input/forward.md    backlog          (0.10.36)
* input/syslog.md     source_host_key  (0.10.53)
* input/tail.md       path_delimiter   (1.9.1)
* parser/multiline.md unmatched_lines  (1.9.3)

The version column is taken from the commit which introduced each `config_param` and the first release tag containing it, not guessed.

Two related fixes on pages touched here:

* input/forward.md: `resolve_hostname` cannot be `false` when `source_hostname_key` is set. The wording matches the note which input/syslog.md already has for the same constraint.
* input/syslog.md: `include_source_host` assigns `@source_address_key`, so it adds the source *address* under the field name given by `source_host_key`, not the hostname.