### PR TITLE
output/exec_filter: document deprecated parameters and section defaults

### DIFF
--- a/output/exec_filter.md
+++ b/output/exec_filter.md
@@ -53,6 +53,8 @@ If the buffering by `Yajl` parser is problematic for you even though you expect 
 
 ## Parameters
 
+[Common Parameters](../configuration/plugin-common-parameters.md)
+
 ### `@type`
 
 The value must be `exec_filter`.
@@ -123,6 +125,68 @@ The format used to map the incoming event to the program input.
 
 The format used to process the program output.
 
+### `remove_prefix`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | nil | 0.10.9 |
+
+This parameter is deprecated since v0.14.9. Use [`@label`](../configuration/plugin-common-parameters.md#label) instead for event routing.
+
+Removes the given prefix and the following `.` from the tag of the incoming event before the event is passed to the program.
+
+The shortened tag is also the value which `tag_key` of the [`<inject>`](#less-than-inject-greater-than-section) section adds to the record.
+
+### `add_prefix`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | nil | 0.10.9 |
+
+This parameter is deprecated since v0.14.9. Use [`@label`](../configuration/plugin-common-parameters.md#label) instead for event routing.
+
+Prepends the given prefix and a `.` to the tag of the outgoing event.
+
+It applies only to a tag taken from the program output by `tag_key` of the [`<extract>`](#less-than-extract-greater-than-section) section. If the tag falls back to the [`tag`](#tag) parameter, the prefix is not added.
+
+### `tag_key`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | nil | 0.14.9 |
+
+This parameter is deprecated since v0.14.9. Use `tag_key` in the [`<inject>`](#less-than-inject-greater-than-section) and [`<extract>`](#less-than-extract-greater-than-section) sections instead.
+
+v0.14.9 is also the version which brought this parameter back. It was dropped during the v0.12 series and reinstated only so that older configurations keep working, which is why it has been deprecated from the start.
+
+Sets `tag_key` of both sections at once.
+
+If the configuration already has one of these sections, this parameter has no effect on that section.
+
+### `time_key`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | nil | 0.10.5 |
+
+This parameter is deprecated since v0.14.9. Use `time_key` in the [`<inject>`](#less-than-inject-greater-than-section) and [`<extract>`](#less-than-extract-greater-than-section) sections instead.
+
+Sets `time_key` of both sections at once.
+
+If the configuration already has one of these sections, this parameter has no effect on that section.
+
+### `time_format`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| string | nil | 0.10.5 |
+
+This parameter is deprecated since v0.14.9. Use `time_format` in the [`<inject>`](#less-than-inject-greater-than-section) and [`<extract>`](#less-than-extract-greater-than-section) sections instead.
+
+Sets `time_format` of both sections at once.
+
+If the configuration already has one of these sections, this parameter has no effect on that section.
+
 ### `<format>` Section
 
 The format used to map the incoming events to the program input.
@@ -175,6 +239,14 @@ Overwrites the default value in this plugin.
 
 Overwrites the default value in this plugin.
 
+#### `estimate_current_event`
+
+| type | default | version |
+| :--- | :--- | :--- |
+| bool | false | 0.14.9 |
+
+Overwrites the default value in this plugin.
+
 ### `<inject>` Section
 
 See [Inject Section Configurations](../configuration/inject-section.md) for more details.
@@ -183,9 +255,11 @@ See [Inject Section Configurations](../configuration/inject-section.md) for more
 
 | type | default | version |
 | :--- | :--- | :--- |
-| enum | float | 0.14.9 |
+| enum | unixtime | 0.14.9 |
 
 Overwrites the default value in this plugin.
+
+If `time_format` is set in this section, `time_type` becomes `string` unless it is set explicitly.
 
 ### `<extract>` Section
 
@@ -197,7 +271,9 @@ See [Extract Section Configurations](../configuration/extract-section.md) for mo
 | :--- | :--- | :--- |
 | enum | float | 0.14.9 |
 
-Overwrite default value in this plugin.
+Overwrites the default value in this plugin.
+
+If `time_format` is set in this section, `time_type` becomes `string` unless it is set explicitly.
 
 ### `<buffer>` Section
 


### PR DESCRIPTION
Five parameters are declared with `deprecated:` in `out_exec_filter.rb` but none of them appeared in the documentation. Users had no way to learn what they do or what to use instead.

* remove_prefix  (0.10.9)  use `@label` instead
* add_prefix     (0.10.9)  use `@label` instead
* tag_key        (0.14.9)  use `tag_key` in `<inject>`/`<extract>`
* time_key       (0.10.5)  use `time_key` in `<inject>`/`<extract>`
* time_format    (0.10.5)  use `time_format` in `<inject>`/`<extract>`

All five became deprecated in v0.14.9 ([fcc4144f](https://github.com/fluent/fluentd/commit/fcc4144f)), which the text states. The version column is the release which first accepted the parameter, confirmed against the release tag contents rather than guessed.

tag_key is the odd one, and the text explains it: v0.14.9 both added and deprecated it. It was introduced in 0.10.5, dropped during the v0.12 series ([eb3ff406](https://github.com/fluent/fluentd/commit/eb3ff406) replaced it with `in_tag_key` / `out_tag_key`), and [fcc4144f](https://github.com/fluent/fluentd/commit/fcc4144f) reinstated it as a compatibility alias with `deprecated:` already attached. v0.14.8 has no declaration at all, so 0.14.9 is correct for the parameter as it exists today even though it looks like a typo next to `time_key` at 0.10.5.

Three related fixes on the same page:

* `## Parameters` had no link to Common Parameters, unlike every other output plugin page.
* The `<inject>` section's time_type default is `unixtime`, not `float`. The plugin overrides the inject helper default with `config_set_default :time_type, :unixtime`.
* The `<parse>` section's estimate_current_event was missing. The plugin overrides the parser default `true` with `false`.

Both time_type entries now note that specifying `time_format` in the same section makes time_type `string`, which is easy to miss because it happens in configure before the section is parsed.