### PR TITLE
Fix in-page anchors broken by the HonKit migration

### DIFF
--- a/deployment/system-config.md
+++ b/deployment/system-config.md
@@ -112,7 +112,7 @@ Invokes a fluentd only with input plugins.
 
 See [Source Only Mode](source-only-mode.md) for details.
 
-See also [source_only_buffer section](#less-than-source_only_buffer-greater-than-section).
+See also [source_only_buffer section](#sourceonlybuffer-section).
 
 ### `rpc_endpoint`
 

--- a/input/http.md
+++ b/input/http.md
@@ -245,7 +245,7 @@ This is useful to keep the log quiet when clients keep sending malformed request
 
 Adds `QUERY_` prefix query parameters to the record.
 
-The name of each query parameter is converted to upper case and `-` is replaced with `_`, in the same way as [`add_http_headers`](#add_http_headers) treats header names. For example, `?user-id=1` adds the `QUERY_USER_ID` field.
+The name of each query parameter is converted to upper case and `-` is replaced with `_`, in the same way as [`add_http_headers`](#addhttpheaders) treats header names. For example, `?user-id=1` adds the `QUERY_USER_ID` field.
 
 ### `add_tag_prefix`
 
@@ -420,7 +420,7 @@ $ curl --data-binary @json.gz -H "Content-Encoding: gzip" \
 
 You do not need any configuration to enable this feature.
 
-Since v1.19.3, the decompressed payload size is limited to 256MB by default. A request whose payload exceeds the limit is rejected with `400 Bad Request`. Use [`decompression_size_limit`](#decompression_size_limit) to change the limit.
+Since v1.19.3, the decompressed payload size is limited to 256MB by default. A request whose payload exceeds the limit is rejected with `400 Bad Request`. Use [`decompression_size_limit`](#decompressionsizelimit) to change the limit.
 
 ### Multi-process Environment
 

--- a/input/syslog.md
+++ b/input/syslog.md
@@ -294,7 +294,7 @@ The field name of the client's address. If set, the client's address will be set
 
 This parameter is deprecated. Use `source_hostname_key` or `source_address_key` instead.
 
-If `true`, adds the source address to the event record. The field name is specified by [`source_host_key`](#source_host_key).
+If `true`, adds the source address to the event record. The field name is specified by [`source_host_key`](#sourcehostkey).
 
 ### `source_host_key`
 

--- a/output/exec_filter.md
+++ b/output/exec_filter.md
@@ -135,7 +135,7 @@ This parameter is deprecated since v0.14.9. Use [`@label`](../configuration/plug
 
 Removes the given prefix and the following `.` from the tag of the incoming event before the event is passed to the program.
 
-The shortened tag is also the value which `tag_key` of the [`<inject>`](#less-than-inject-greater-than-section) section adds to the record.
+The shortened tag is also the value which `tag_key` of the [`<inject>`](#inject-section) section adds to the record.
 
 ### `add_prefix`
 
@@ -147,7 +147,7 @@ This parameter is deprecated since v0.14.9. Use [`@label`](../configuration/plug
 
 Prepends the given prefix and a `.` to the tag of the outgoing event.
 
-It applies only to a tag taken from the program output by `tag_key` of the [`<extract>`](#less-than-extract-greater-than-section) section. If the tag falls back to the [`tag`](#tag) parameter, the prefix is not added.
+It applies only to a tag taken from the program output by `tag_key` of the [`<extract>`](#extract-section) section. If the tag falls back to the [`tag`](#tag) parameter, the prefix is not added.
 
 ### `tag_key`
 
@@ -155,7 +155,7 @@ It applies only to a tag taken from the program output by `tag_key` of the [`<ex
 | :--- | :--- | :--- |
 | string | nil | 0.14.9 |
 
-This parameter is deprecated since v0.14.9. Use `tag_key` in the [`<inject>`](#less-than-inject-greater-than-section) and [`<extract>`](#less-than-extract-greater-than-section) sections instead.
+This parameter is deprecated since v0.14.9. Use `tag_key` in the [`<inject>`](#inject-section) and [`<extract>`](#extract-section) sections instead.
 
 v0.14.9 is also the version which brought this parameter back. It was dropped during the v0.12 series and reinstated only so that older configurations keep working, which is why it has been deprecated from the start.
 
@@ -169,7 +169,7 @@ If the configuration already has one of these sections, this parameter has no ef
 | :--- | :--- | :--- |
 | string | nil | 0.10.5 |
 
-This parameter is deprecated since v0.14.9. Use `time_key` in the [`<inject>`](#less-than-inject-greater-than-section) and [`<extract>`](#less-than-extract-greater-than-section) sections instead.
+This parameter is deprecated since v0.14.9. Use `time_key` in the [`<inject>`](#inject-section) and [`<extract>`](#extract-section) sections instead.
 
 Sets `time_key` of both sections at once.
 
@@ -181,7 +181,7 @@ If the configuration already has one of these sections, this parameter has no ef
 | :--- | :--- | :--- |
 | string | nil | 0.10.5 |
 
-This parameter is deprecated since v0.14.9. Use `time_format` in the [`<inject>`](#less-than-inject-greater-than-section) and [`<extract>`](#less-than-extract-greater-than-section) sections instead.
+This parameter is deprecated since v0.14.9. Use `time_format` in the [`<inject>`](#inject-section) and [`<extract>`](#extract-section) sections instead.
 
 Sets `time_format` of both sections at once.
 

--- a/output/file.md
+++ b/output/file.md
@@ -27,7 +27,7 @@ With this configuration, files named `/var/log/fluent/myapp.{%Y%m%d}.log.gz` wil
 
 Please see the [Configuration File](../configuration/config-file.md) article for the basic structure and syntax of the configuration file.
 
-For `<buffer>`, refer to [`<buffer>` Section](#less-than-buffer-greater-than-section).
+For `<buffer>`, refer to [`<buffer>` Section](#buffer-section).
 
 ## Plugin Helpers
 
@@ -60,7 +60,7 @@ path /path/to/${tag}/${key1}/file.%Y%m%d
 </buffer>
 ```
 
-See [`<buffer>` Section](#less-than-buffer-greater-than-section) for more detail.
+See [`<buffer>` Section](#buffer-section) for more detail.
 
 The `path` parameter is used as `<buffer>`'s `path` in this plugin.
 

--- a/output/http.md
+++ b/output/http.md
@@ -61,7 +61,7 @@ endpoint http://example.com/api/${tag}-${key}
 
 See [Buffer Section Configurations](../configuration/buffer-section.md) for more details.
 
-Since v1.19.3, if a placeholder is used in the host part of the endpoint, [`allowed_hosts`](#allowed_hosts) must also be set. A placeholder used only in the path or the query string is not affected.
+Since v1.19.3, if a placeholder is used in the host part of the endpoint, [`allowed_hosts`](#allowedhosts) must also be set. A placeholder used only in the path or the query string is not affected.
 
 ### `allowed_hosts`
 


### PR DESCRIPTION
HonKit builds heading ids differently from GitBook: it drops backticks, `<`, `>` and `_` from the heading text. The links written for GitBook therefore stopped resolving once #671 and #672 made HonKit the renderer for the published site.

| heading                     | GitBook id                             | HonKit id      |
| --------------------------- | -------------------------------------- | -------------- |
| `### `add_http_headers``    | add_http_headers                       | addhttpheaders |
| `### `<inject>` Section`    | less-than-inject-greater-than-section  | inject-section |

15 links across 6 files, 8 distinct anchors:

* input/http.md               #add_http_headers, #decompression_size_limit
* input/syslog.md             #source_host_key
* output/http.md              #allowed_hosts
* output/exec_filter.md       #less-than-{inject,extract}-greater-than-section
* output/file.md              #less-than-buffer-greater-than-section
* deployment/system-config.md #less-than-source_only_buffer-greater-than-section

Verified by building the site with the repository's own configuration and matching every `href="#..."` against the `id=` and `name=` attributes on the same page. Before this change 8 of the 2366 in-page anchors did not resolve; after it, none are left.

The new ids were read out of the generated HTML rather than derived from the rule by hand.