### PR TITLE
Replace default search plugins with search-plus

### DIFF
--- a/book.json
+++ b/book.json
@@ -9,7 +9,8 @@
 		"intopic-toc",
 		"partial-summary",
 		"localized-footer",
-		"versions-select"
+		"versions-select",
+		"-lunr", "-search", "search-plus"
 	],
 
 	"pluginsConfig": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "gitbook-plugin-partial-summary": "1.0.0",
         "gitbook-plugin-versions-select": "0.1.1",
         "honkit": "6.2.2",
-        "honkit-plugin-breadcrumbs": "0.0.3"
+        "honkit-plugin-breadcrumbs": "0.0.3",
+        "honkit-plugin-search-plus": "1.0.0"
       }
     },
     "node_modules/@asciidoctor/cli": {
@@ -1186,6 +1187,18 @@
       "integrity": "sha512-9E8FL3NbR+mTFu8Xgvqvz3gHmcuYV4kFuYU8pfom1mUjWAZc8BmHw4Ju4VaNNw+PqCNrL8uo8IPuskHuHV4pXg==",
       "engines": {
         "honkit": ">1.x.x"
+      }
+    },
+    "node_modules/honkit-plugin-search-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/honkit-plugin-search-plus/-/honkit-plugin-search-plus-1.0.0.tgz",
+      "integrity": "sha512-GnfzHS+HhZUWLeCkprXH7et1nSuzR23HYqRw1HJbz17UnmHRdTxhBalK37uZayI3xAdA4C2anei9phXrjpDSmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "html-entities": "1.2.0"
+      },
+      "engines": {
+        "gitbook": ">=3.0.0"
       }
     },
     "node_modules/honkit/node_modules/dom-serializer": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gitbook-plugin-partial-summary": "1.0.0",
     "gitbook-plugin-versions-select": "0.1.1",
     "honkit": "6.2.2",
-    "honkit-plugin-breadcrumbs": "0.0.3"
+    "honkit-plugin-breadcrumbs": "0.0.3",
+    "honkit-plugin-search-plus": "1.0.0"
   }
 }


### PR DESCRIPTION
The default search stack (search + lunr plugins) had two practical
problems on docs.fluentd.org:

* The generated search_index.json is about 6.7 MB (837 KB gzipped)
  and is fetched and parsed eagerly on every page view. Queries typed
  before loading completes throw "Search has not been initialized"
  with no visible error, and the typed query is never re-executed
  once the index becomes ready. As a result the search box appears
  broken right after page load. Since the length of this window
  depends on network and cache timing, the behavior also looks
  inconsistent across browsers.

* lunr applies an English stopword filter, so common words such as
  "for" always return "No results matching" even though they clearly
  appear in the documentation.
