### PR TITLE
1.0: follow from rewrite cache-control

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,6 +17,22 @@
   to = "/1.0/assets/:splat"
   status = 200
 
+# follow "from .gitbook/assets" rewrite rule
+[[headers]]
+  for = "/.gitbook/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=604800"
+
+[[headers]]
+  for = "/1.0/.gitbook/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=604800"
+
+[[headers]]
+  for = "/0.12/.gitbook/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=604800"
+
 # weekly cache (7 * 86400)
 [[headers]]
   for = "/images/*"


### PR DESCRIPTION
The following /assets/, /1.0/assets/ and /0.12/assets/ were covered in [[headers]] rule, but hidden .gitbook/assets rule were not covered yet.
Thus, cache-control header is not changed for ".gitbook/assets" targets.

e.g. .gitbook/assets cache-control should be fixed in the following use-case.

> curl -sI https://docs.fluentd.org/assets/kafka.png |grep -i 'cache-control'
cache-control: public,max-age=604800
> curl -sI https://docs.fluentd.org/.gitbook/assets/kafka.png |grep -i 'cache-control'
cache-control: public,max-age=0,must-revalidate