### PR TITLE
Document missing Plugin Helpers and Common Parameters links

### DIFF
--- a/filter/record_transformer.md
+++ b/filter/record_transformer.md
@@ -92,6 +92,10 @@ Finally, this configuration embeds the value of the second part of the tag in th
 
 So, if an event with the tag `web.auth` and record `{"user_id":1, "status":"ok"}` comes in, it transforms it into `{"user_id":1, "status":"ok", "service_name":"auth"}`.
 
+## Plugin Helpers
+
+* [`record_accessor`](../plugin-helper-overview/api-plugin-helper-record_accessor.md)
+
 ## Parameters
 
 See [Common Parameters](../configuration/plugin-common-parameters.md).

--- a/formatter/csv.md
+++ b/formatter/csv.md
@@ -6,6 +6,10 @@ The `csv` formatter plugin outputs an event as CSV.
 "value1"[delimiter]"value2"[delimiter]"value3"[newline]
 ```
 
+## Plugin Helpers
+
+* [`record_accessor`](../plugin-helper-overview/api-plugin-helper-record_accessor.md)
+
 ## Parameters
 
 * [Common Parameters](../configuration/plugin-common-parameters.md)

--- a/input/monitor_agent.md
+++ b/input/monitor_agent.md
@@ -28,6 +28,12 @@ $ curl http://host:24220/api/plugins
 
 Refer to the [Configuration File](../configuration/config-file.md) article for the basic structure and syntax of the configuration file.
 
+## Plugin Helpers
+
+* [`timer`](../plugin-helper-overview/api-plugin-helper-timer.md)
+* [`thread`](../plugin-helper-overview/api-plugin-helper-thread.md)
+* [`http_server`](../plugin-helper-overview/api-plugin-helper-http_server.md)
+
 ## Parameters
 
 See [Common Parameters](../configuration/plugin-common-parameters.md).

--- a/input/unix.md
+++ b/input/unix.md
@@ -15,7 +15,13 @@ It is included in Fluentd's core.
 
 Refer to the [Configuration File](../configuration/config-file.md) article for the basic structure and syntax of the configuration file.
 
+## Plugin Helpers
+
+* [`event_loop`](../plugin-helper-overview/api-plugin-helper-event_loop.md)
+
 ## Parameters
+
+See [Common Parameters](../configuration/plugin-common-parameters.md).
 
 ### `@type` \(required\)
 

--- a/output/http.md
+++ b/output/http.md
@@ -28,7 +28,13 @@ Please see the [Configuration File](../configuration/config-file.md) article for
 
 For `<buffer>`, refer to [Buffer Section Configuration](../configuration/buffer-section.md).
 
+## Plugin Helpers
+
+* [`formatter`](../plugin-helper-overview/api-plugin-helper-formatter.md)
+
 ## Parameters
+
+[Common Parameters](../configuration/plugin-common-parameters.md)
 
 ### `@type`
 

--- a/service_discovery/file.md
+++ b/service_discovery/file.md
@@ -30,6 +30,10 @@ Here is an example of target list file \(`/etc/fluentd/sd.yaml`\):
   'name': server2
 ```
 
+## Plugin Helpers
+
+* [`event_loop`](../plugin-helper-overview/api-plugin-helper-event_loop.md)
+
 ## Parameters
 
 ### `@type`

--- a/service_discovery/srv.md
+++ b/service_discovery/srv.md
@@ -19,6 +19,10 @@ Here is an example of `out_forward` updating the targets to get the SRV record f
 </match>
 ```
 
+## Plugin Helpers
+
+* [`timer`](../plugin-helper-overview/api-plugin-helper-timer.md)
+
 ## Parameters
 
 ### `@type`


### PR DESCRIPTION
Add the Plugin Helpers section to the seven pages whose plugins declare helpers but do not list them, keeping the order of each `helpers` line.
Also add the Common Parameters link missing from `in_unix` and `out_http`.