### PR TITLE
Point the v0.12 links at docs.fluentd.org

### DIFF
--- a/appendix/update-from-v0.12.md
+++ b/appendix/update-from-v0.12.md
@@ -83,4 +83,4 @@ Fluentd v1 changes buffer mechanism for flexibility. The new buffer consists of 
 
 ### Log Forwarding from v1.0 to v0.12
 
-Log forwarding from v0.12 to v1.0 is no problem but log forwarding from v1.0 to v0.12 has a problem due to timestamp change. See [`in_forward`'s FAQ](https://fluentd.gitbook.io/manual/v/0.12/input/forward#i-got-messagepack-unknownexttypeerror-error-why)
+Log forwarding from v0.12 to v1.0 is no problem but log forwarding from v1.0 to v0.12 has a problem due to timestamp change. See [`in_forward`'s FAQ](https://docs.fluentd.org/0.12/input/forward#i-got-messagepackunknownexttypeerror-error-why)

--- a/deployment/logging.md
+++ b/deployment/logging.md
@@ -329,4 +329,4 @@ If an error occurs, you will get a notification message in your Slack `notify` c
 
 ### Deprecate Top-Level Match
 
-You can still use [v0.12 way](https://fluentd.gitbook.io/manual/v/0.12/deployment/logging#capture-fluentd-logs) without `<label @FLUENT_LOG>` but this feature is deprecated. This feature will be removed in fluentd v2.
+You can still use [v0.12 way](https://docs.fluentd.org/0.12/deployment/logging#capture-fluentd-logs) without `<label @FLUENT_LOG>` but this feature is deprecated. This feature will be removed in fluentd v2.


### PR DESCRIPTION
The two links to the v0.12 manual still use the old GitBook domain. They redirect, but the rest of the docs now write v0.12 URLs as docs.fluentd.org/0.12, so use that form here as well.

The `in_forward` anchor fixed on the way as well.